### PR TITLE
Update to Rust master

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -34,7 +34,7 @@ impl INotifyWatcher {
             match e.kind {
               IoErrorKind::EndOfFile => break,
               _ => {
-                tx.send_opt(Event {
+                let _ = tx.send_opt(Event {
                   path: None,
                   op: Err(Error::Io(e))
                 });

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -33,10 +33,12 @@ impl INotifyWatcher {
           Err(e) => {
             match e.kind {
               IoErrorKind::EndOfFile => break,
-              _ => tx.send(Event {
-                path: None,
-                op: Err(Error::Io(e))
-              })
+              _ => {
+                tx.send_opt(Event {
+                  path: None,
+                  op: Err(Error::Io(e))
+                });
+              }
             }
           }
         }
@@ -91,7 +93,7 @@ impl Watcher for INotifyWatcher {
       },
       Err(e) => return Err(Error::Io(e))
     };
-    
+
     it.run();
     return Ok(it);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,12 @@ pub mod op {
   }
 }
 
-#[deriving(Send)]
 pub struct Event {
   pub path: Option<Path>,
   pub op: Result<Op, Error>,
 }
+
+unsafe impl Send for Event {}
 
 pub enum Error {
   Generic(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub fn new(tx: Sender<Event>) -> Result<RecommendedWatcher, Error> {
 #[test]
 #[cfg(target_os = "linux")]
 fn new_inotify() {
-  let (tx, rx) = channel();
+  let (tx, _) = channel();
   let w: Result<INotifyWatcher, Error> = Watcher::new(tx);
   match w {
     Ok(_) => assert!(true),
@@ -64,7 +64,7 @@ fn new_inotify() {
 
 #[test]
 fn new_poll() {
-  let (tx, rx) = channel();
+  let (tx, _) = channel();
   let w: Result<PollWatcher, Error> = Watcher::new(tx);
   match w {
     Ok(_) => assert!(true),
@@ -74,7 +74,7 @@ fn new_poll() {
 
 #[test]
 fn new_recommended() {
-  let (tx, rx) = channel();
+  let (tx, _) = channel();
   let w: Result<RecommendedWatcher, Error> = Watcher::new(tx);
   match w {
     Ok(_) => assert!(true),


### PR DESCRIPTION
Send trait is an unsafe trait and it cannot be derived anymore, therefore `unsafe impl` is needed. I got a panic when running tests (not always, but like 30% of the time) because the test tried to send data to a closed channel. So I changed a send to send_opt just to get rid of those panics (not that they would matter much). Also silenced all warnings.