### PR TITLE
update to latest rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ keywords = [
 
 [dependencies]
 time = "*"
+bitflags = "*"
 
 [target.x86_64-unknown-linux-gnu.dependencies.inotify]
 version = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unstable)]
 
 #[plugin] extern crate log;
+#[macro_use] extern crate bitflags;
 
 use std::io::IoError;
 use std::sync::mpsc::Sender;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
-#![feature(phase)]
-#[phase(plugin, link)] extern crate log;
+#![feature(plugin)]
+#![allow(unstable)]
+
+#[plugin] extern crate log;
 
 use std::io::IoError;
 use std::sync::mpsc::Sender;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,14 +1,14 @@
 use std::collections::{HashMap, HashSet};
 use std::io::fs::{self, PathExtensions};
-use std::sync::{Arc, RWLock};
+use std::sync::{Arc, RwLock};
 use std::sync::mpsc::Sender;
 use std::thread::Thread;
 use super::{Error, Event, op, Watcher};
 
 pub struct PollWatcher {
   tx: Sender<Event>,
-  watches: Arc<RWLock<HashSet<Path>>>,
-  open: Arc<RWLock<bool>>
+  watches: Arc<RwLock<HashSet<Path>>>,
+  open: Arc<RwLock<bool>>
 }
 
 impl PollWatcher {
@@ -16,7 +16,7 @@ impl PollWatcher {
     let tx = self.tx.clone();
     let watches = self.watches.clone();
     let open = self.open.clone();
-    Thread::spawn(move || {
+    Thread::scoped(move || {
       // In order of priority:
       // TODO: populate mtimes before loop, and then handle creation events
       // TODO: handle deletion events
@@ -110,8 +110,8 @@ impl Watcher for PollWatcher {
   fn new(tx: Sender<Event>) -> Result<PollWatcher, Error> {
     let mut p = PollWatcher {
       tx: tx,
-      watches: Arc::new(RWLock::new(HashSet::new())),
-      open: Arc::new(RWLock::new(true))
+      watches: Arc::new(RwLock::new(HashSet::new())),
+      open: Arc::new(RwLock::new(true))
     };
     p.run();
     Ok(p)


### PR DESCRIPTION
* `RWLock` renamed to `RwLock`
* `Thread::spawn()` now returns Thread struct, `Thread::scoped()` is for ThreadGuard now