### PR TITLE
use the new std::{fs, path}

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -3,20 +3,20 @@ extern crate libc;
 
 use self::inotify_sys::wrapper::{self, INotify, Watch};
 use std::collections::HashMap;
-use std::old_io::IoErrorKind;
-use std::old_io::fs::{PathExtensions, walk_dir};
+use std::fs::{PathExt, walk_dir};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, RwLock};
 use std::thread::Thread;
 use super::{Error, Event, op, Op, Watcher};
+use std::path::{Path, PathBuf};
 
 mod flags;
 
 pub struct INotifyWatcher {
   inotify: INotify,
   tx: Sender<Event>,
-  watches: HashMap<Path, (Watch, flags::Mask)>,
-  paths: Arc<RwLock<HashMap<Watch, Path>>>
+  watches: HashMap<PathBuf, (Watch, flags::Mask)>,
+  paths: Arc<RwLock<HashMap<Watch, PathBuf>>>
 }
 
 impl INotifyWatcher {
@@ -27,14 +27,14 @@ impl INotifyWatcher {
     Thread::spawn(move || {
       loop {
         match ino.wait_for_events() {
+          Ok(es) if es.is_empty() => break,
           Ok(es) => {
             for e in es.iter() {
               handle_event(e.clone(), &tx, &paths)
             }
           },
           Err(e) => {
-            match e.kind {
-              IoErrorKind::EndOfFile => break,
+            match e.kind() {
               _ => {
                 let _ = tx.send(Event {
                   path: None,
@@ -57,7 +57,8 @@ impl INotifyWatcher {
                       | flags::IN_MOVED_FROM
                       | flags::IN_MOVED_TO
                       | flags::IN_MOVE_SELF;
-    match self.watches.get(path) {
+    let path = path.to_path_buf();
+    match self.watches.get(&path) {
       None => {},
       Some(p) => {
         watching.insert((&p.1).clone());
@@ -65,12 +66,12 @@ impl INotifyWatcher {
       }
     }
 
-    match self.inotify.add_watch(path, watching.bits()) {
+    match self.inotify.add_watch(&path, watching.bits()) {
       Err(e) => return Err(Error::Io(e)),
       Ok(w) => {
         watching.remove(flags::IN_MASK_ADD);
         self.watches.insert(path.clone(), (w.clone(), watching));
-        (*self.paths).write().unwrap().insert(w.clone(), path.clone());
+        (*self.paths).write().unwrap().insert(w.clone(), path);
         Ok(())
       }
     }
@@ -78,7 +79,7 @@ impl INotifyWatcher {
 }
 
 #[inline]
-fn handle_event(event: wrapper::Event, tx: &Sender<Event>, paths: &Arc<RwLock<HashMap<Watch, Path>>>) {
+fn handle_event(event: wrapper::Event, tx: &Sender<Event>, paths: &Arc<RwLock<HashMap<Watch, PathBuf>>>) {
   let mut o = Op::empty();
   if event.is_create() || event.is_moved_to() {
     o.insert(op::CREATE);
@@ -103,7 +104,7 @@ fn handle_event(event: wrapper::Event, tx: &Sender<Event>, paths: &Arc<RwLock<Ha
         None => None
       }
     },
-    false => Path::new_opt(event.name)
+    false => Some(PathBuf::new(&event.name)),
   };
 
   let _ = tx.send(Event {
@@ -130,12 +131,20 @@ impl Watcher for INotifyWatcher {
 
   fn watch(&mut self, path: &Path) -> Result<(), Error> {
     match walk_dir(path) {
-      Ok(mut d) => {
-        for ref dir in d {
-          if dir.is_dir() {
-            try!(self.add_watch(dir));
+      Ok(d) => {
+        for dir in d {
+          match dir {
+            Ok(entry) => {
+              let path = entry.path();
+
+              if path.is_dir() {
+                try!(self.add_watch(&path));
+              }
+            },
+            Err(e) => return Err(Error::Io(e)),
           }
         }
+
         self.add_watch(path)
       },
       Err(e) => Err(Error::Io(e))
@@ -143,7 +152,10 @@ impl Watcher for INotifyWatcher {
   }
 
   fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
-    match self.watches.remove(path) {
+    // FIXME:
+    // once https://github.com/rust-lang/rust/pull/22351 gets merged,
+    // just use a &Path
+    match self.watches.remove(&path.to_path_buf()) {
       None => Err(Error::WatchNotFound),
       Some(p) => {
         let w = &p.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
+#![feature(path, io, core, rustc_private, libc, hash, std_misc, fs)]
+
 #[macro_use] extern crate log;
 #[macro_use] extern crate rustc_bitflags;
 
-use std::old_io::IoError;
 use std::sync::mpsc::Sender;
 #[cfg(test)] use std::sync::mpsc::channel;
 pub use self::op::Op;
 #[cfg(target_os="linux")]
 pub use self::inotify::INotifyWatcher;
 pub use self::poll::PollWatcher;
+use std::io;
+
+use std::path::{Path, PathBuf};
 
 #[cfg(target_os="linux")]
 pub mod inotify;
@@ -26,7 +30,7 @@ pub mod op {
 }
 
 pub struct Event {
-  pub path: Option<Path>,
+  pub path: Option<PathBuf>,
   pub op: Result<Op, Error>,
 }
 
@@ -34,7 +38,7 @@ unsafe impl Send for Event {}
 
 pub enum Error {
   Generic(String),
-  Io(IoError),
+  Io(io::Error),
   NotImplemented,
   PathNotFound,
   WatchNotFound,


### PR DESCRIPTION
This also requires an updated inotify-rs which you can find [in this branch](https://github.com/blaenk/inotify-rs/tree/new-io) (see the [PR](https://github.com/hannobraun/inotify-rs/pull/14)). It basically uses the new `std::io` for errors. You can use it like this:

``` toml
[target.x86_64-unknown-linux-gnu.dependencies.inotify]
git = "git@github.com:blaenk/inotify-rs.git"
branch = "new-io"
```

So `Path` is to `str` as `PathBuf` is to `String`, as I'm sure you already know. So things that contained `Path`s, like `HashMaps`, now contain `PathBuf`s.

One consequence of updating the inotify-rs package to use the new `std::io` is that there is no longer an `EndOfFile` variant of `ErrorKind`. Instead, `read` returns a `0` on EOF. I'm not sure exactly what should be done in this case, in the context of inotify, so in my inotify-rs branch I just returned an empty slice. This may change if you guys decide there's something else that should be done instead. Read [the PR](https://github.com/hannobraun/inotify-rs/pull/14) for more information.

One problem right now is that we forgot to implement `Hash` for `Path`; it's only implemented for `PathBuf`. This means that if you want to perform operations on a hashmap that contains `PathBuf` keys, but you only have a `&Path`, you have to convert it to a `PathBuf` in order to index the hashmap. [I filed a PR](https://github.com/rust-lang/rust/pull/22351) for this for rust, and for now added FIXME comments so we can remember to change this when it lands.

One slightly tedious change is that `fs::walk_dir` now returns an iterator that itself yields `Result`s. If the result is `Ok`, it yields a `DirEntry` type which you call `path()` on to get the actual Path.

As with my inotify-rs PR, I updated this to use the new `std::io::Error` instead of `IoError`.

Now, instead of `lstat()`, we use the `metadata()` method which has a `modified()` method which we can use.