### PR TITLE
don't break when the event slice is empty

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -27,7 +27,6 @@ impl INotifyWatcher {
     Thread::spawn(move || {
       loop {
         match ino.wait_for_events() {
-          Ok(es) if es.is_empty() => break,
           Ok(es) => {
             for e in es.iter() {
               handle_event(e.clone(), &tx, &paths)


### PR DESCRIPTION
This was actually a mistake, since it's possible that the current call yields no events but we still want to keep checking.