### PR TITLE
include full path to the file that triggered the event

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -103,7 +103,7 @@ fn handle_event(event: wrapper::Event, tx: &Sender<Event>, paths: &Arc<RwLock<Ha
         None => None
       }
     },
-    false => Some(PathBuf::new(&event.name)),
+    false => paths.read().unwrap().get(&event.wd).map(|root| root.join(&event.name)),
   };
 
   let _ = tx.send(Event {


### PR DESCRIPTION
The `Event::path`, when given by inotify, only gives the `Path::file_name`, because it has no notion of recursive watches. The good thing is that we already store a map of directory paths to inotify watchers, so we can use that to join the file name in the inotify event. This way, a deeply nested event yields the appropriate, full path, otherwise we have no way of distinguishing separate files with the same name, and therefore make sit impossible to locate the file that the event is for.