### PR TITLE
Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ keywords = [
 
 [dependencies]
 time = "*"
+bitflags = "*"
 
 [target.x86_64-unknown-linux-gnu.dependencies.inotify]
 version = "^0.1"

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -151,10 +151,7 @@ impl Watcher for INotifyWatcher {
   }
 
   fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
-    // FIXME:
-    // once https://github.com/rust-lang/rust/pull/22351 gets merged,
-    // just use a &Path
-    match self.watches.remove(&path.to_path_buf()) {
+    match self.watches.remove(path) {
       None => Err(Error::WatchNotFound),
       Some(p) => {
         let w = &p.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(rustc_private, libc, fs_time, fs_walk, path_ext)]
 
 #[macro_use] extern crate log;
-#[macro_use] extern crate rustc_bitflags;
+#[macro_use] extern crate bitflags;
 
 use std::sync::mpsc::Sender;
 #[cfg(test)] use std::sync::mpsc::channel;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -131,18 +131,12 @@ impl Watcher for PollWatcher {
   }
 
   fn watch(&mut self, path: &Path) -> Result<(), Error> {
-    // FIXME:
-    // once https://github.com/rust-lang/rust/pull/22351 gets merged,
-    // just use a &Path
     (*self.watches).write().unwrap().insert(path.to_path_buf());
     Ok(())
   }
 
   fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
-    // FIXME:
-    // once https://github.com/rust-lang/rust/pull/22351 gets merged,
-    // just use a &Path
-    if (*self.watches).write().unwrap().remove(&path.to_path_buf()) {
+    if (*self.watches).write().unwrap().remove(path) {
       Ok(())
     } else {
       Err(Error::WatchNotFound)


### PR DESCRIPTION
There's also a deprecation warning about using `modified()`. Not sure how to go about getting the modified time in a cross-platform manner. I think we'd have to define our own functions with a different implementation using the `cfg` attr. I'll leave that to you though.

```
src/poll.rs:51:55: 51:65 warning: use of deprecated item: use os::platform::fs::MetadataExt extension traits, #[warn(deprecated)] on by default
src/poll.rs:51               match mtimes.insert(watch.clone(), stat.modified()) {
                                                                     ^~~~~~~~~~
src/poll.rs:54:27: 54:37 warning: use of deprecated item: use os::platform::fs::MetadataExt extension traits, #[warn(deprecated)] on by default
src/poll.rs:54                   if stat.modified() > old {
                                         ^~~~~~~~~~
src/poll.rs:91:64: 91:74 warning: use of deprecated item: use os::platform::fs::MetadataExt extension traits, #[warn(deprecated)] on by default
src/poll.rs:91                         match mtimes.insert(path.clone(), stat.modified()) {
                                                                              ^~~~~~~~~~
src/poll.rs:94:37: 94:47 warning: use of deprecated item: use os::platform::fs::MetadataExt extension traits, #[warn(deprecated)] on by default
src/poll.rs:94                             if stat.modified() > old {
                                                   ^~~~~~~~~~
```