### PR TITLE
reintroduce pollwatcher now that rust 1.1 is out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bitflags = "*"
 libc = "*"
 log = "*"
 time = "*"
+filetime = "*"
 walker = "^1.0.0"
 
 [target.x86_64-unknown-linux-gnu.dependencies.inotify]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Notify
 
-__NOTICE: I need a usable-in-stable replacement for `stat.modified()` i.e.
-a cross-platform way of getting the mtime of a file. Without that, the polling
-backend will be left out, and I do not currently have the time to do it myself,
-so [*please help*](https://github.com/passcod/rsnotify/issues/12). Thank you.__
-
 _Cross-platform filesystem notification library for Rust._
 
 ## Install
@@ -50,8 +45,8 @@ fn main() {
 ## Platforms
 
 - Linux / Android: inotify
-- ~~All platforms: polling~~ (not working, see notice)
 - OS X: FSEvent
+- All platforms: polling
 
 ### Todo
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #[macro_use] extern crate bitflags;
 #[cfg(target_os="macos")] extern crate fsevent_sys;
 extern crate libc;
+extern crate filetime;
 
 pub use self::op::Op;
 use std::io;
@@ -12,10 +13,12 @@ use std::sync::mpsc::Sender;
 #[cfg(target_os="macos")] pub use self::fsevent::FsEventWatcher;
 #[cfg(target_os="linux")] pub use self::inotify::INotifyWatcher;
 pub use self::null::NullWatcher;
+pub use self::poll::PollWatcher;
 
 #[cfg(target_os="linux")] pub mod inotify;
 #[cfg(target_os="macos")] pub mod fsevent;
 pub mod null;
+pub mod poll;
 
 pub mod op {
   bitflags! {
@@ -53,7 +56,7 @@ pub trait Watcher {
 
 #[cfg(target_os = "linux")] pub type RecommendedWatcher = INotifyWatcher;
 #[cfg(target_os = "macos")] pub type RecommendedWatcher = FsEventWatcher;
-#[cfg(not(any(target_os = "linux", target_os = "macos")))] pub type RecommendedWatcher = NullWatcher;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))] pub type RecommendedWatcher = PollWatcher;
 
 pub fn new(tx: Sender<Event>) -> Result<RecommendedWatcher, Error> {
   Watcher::new(tx)
@@ -85,6 +88,16 @@ fn new_fsevent() {
 fn new_null() {
   let (tx, _) = channel();
   let w: Result<NullWatcher, Error> = Watcher::new(tx);
+  match w {
+    Ok(_) => assert!(true),
+    Err(_) => assert!(false)
+  }
+}
+
+#[test]
+fn new_poll() {
+  let (tx, _) = channel();
+  let w: Result<PollWatcher, Error> = Watcher::new(tx);
   match w {
     Ok(_) => assert!(true),
     Err(_) => assert!(false)

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,0 +1,168 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+use std::sync::mpsc::Sender;
+use std::fs;
+use std::thread;
+use super::{Error, Event, op, Watcher};
+use std::path::{Path, PathBuf};
+use self::walker::Walker;
+
+use filetime::FileTime;
+
+extern crate walker;
+
+pub struct PollWatcher {
+  tx: Sender<Event>,
+  watches: Arc<RwLock<HashSet<PathBuf>>>,
+  open: Arc<RwLock<bool>>
+}
+
+impl PollWatcher {
+  fn run(&mut self) {
+    let tx = self.tx.clone();
+    let watches = self.watches.clone();
+    let open = self.open.clone();
+    thread::spawn(move || {
+      // In order of priority:
+      // TODO: populate mtimes before loop, and then handle creation events
+      // TODO: handle deletion events
+      // TODO: handle chmod events
+      // TODO: handle renames
+      // TODO: DRY it up
+      let mut mtimes: HashMap<PathBuf, u64> = HashMap::new();
+      loop {
+        if !(*open.read().unwrap()) {
+          break
+        }
+
+        for watch in watches.read().unwrap().iter() {
+          let meta = fs::metadata(watch);
+
+          if !meta.is_ok() {
+            let _ = tx.send(Event {
+              path: Some(watch.clone()),
+              op: Err(Error::PathNotFound)
+            });
+            continue
+          }
+
+          match meta {
+            Err(e) => {
+              let _ = tx.send(Event {
+                path: Some(watch.clone()),
+                op: Err(Error::Io(e))
+              });
+              continue
+            },
+            Ok(stat) => {
+              let modified =
+                FileTime::from_last_modification_time(&stat)
+                .seconds();
+
+              match mtimes.insert(watch.clone(), modified) {
+                None => continue, // First run
+                Some(old) => {
+                  if modified > old {
+                    let _ = tx.send(Event {
+                      path: Some(watch.clone()),
+                      op: Ok(op::WRITE)
+                    });
+                    continue
+                  }
+                }
+              }
+            }
+          }
+
+          // TODO: more efficient implementation where the dir tree is cached?
+          match Walker::new(watch) {
+            Err(e) => {
+              let _ = tx.send(Event {
+                path: Some(watch.clone()),
+                op: Err(Error::Io(e))
+              });
+              continue
+            },
+            Ok(iter) => {
+              for entry in iter {
+                match entry {
+                  Ok(entry) => {
+                    let path = entry.path();
+
+                    match fs::metadata(&path) {
+                      Err(e) => {
+                        let _ = tx.send(Event {
+                          path: Some(path.clone()),
+                          op: Err(Error::Io(e))
+                        });
+                        continue
+                      },
+                      Ok(stat) => {
+                        let modified =
+                          FileTime::from_last_modification_time(&stat)
+                          .seconds();
+
+                        match mtimes.insert(path.clone(), modified) {
+                          None => continue, // First run
+                          Some(old) => {
+                            if modified > old {
+                              let _ = tx.send(Event {
+                                path: Some(path.clone()),
+                                op: Ok(op::WRITE)
+                              });
+                              continue
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  Err(e) => {
+                    let _ = tx.send(Event {
+                      path: Some(watch.clone()),
+                      op: Err(Error::Io(e))
+                    });
+                  },
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+}
+
+impl Watcher for PollWatcher {
+  fn new(tx: Sender<Event>) -> Result<PollWatcher, Error> {
+    let mut p = PollWatcher {
+      tx: tx,
+      watches: Arc::new(RwLock::new(HashSet::new())),
+      open: Arc::new(RwLock::new(true))
+    };
+    p.run();
+    Ok(p)
+  }
+
+  fn watch(&mut self, path: &Path) -> Result<(), Error> {
+    (*self.watches).write().unwrap().insert(path.to_path_buf());
+    Ok(())
+  }
+
+  fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
+    if (*self.watches).write().unwrap().remove(path) {
+      Ok(())
+    } else {
+      Err(Error::WatchNotFound)
+    }
+  }
+}
+
+impl Drop for PollWatcher {
+  fn drop(&mut self) {
+    {
+      let mut open = (*self.open).write().unwrap();
+      (*open) = false;
+    }
+  }
+}


### PR DESCRIPTION
Closes #12

This uses @acrichto's `filetime` crate for modified time fetching.