### PR TITLE
Replace Path with AsRef<Path> in Watcher functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
   "Pierre Baillet <oct@zoy.org>",
   "ShuYu Wang <andelf@gmail.com>",
   "Jimmy Lu <gongchuo.lu@gmail.com>",
+  "Francisco Giordano <frangio.1@gmail.com>",
 ]
 
 description = "Cross-platform filesystem notification library"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn main() {
     Ok(mut watcher) => {
       // Add a path to be watched. All files and directories at that path and
       // below will be monitored for changes.
-      watcher.watch(&Path::new("/home/test/notify"));
+      watcher.watch("/home/test/notify");
 
       // You'll probably want to do that in a loop. The type to match for is
       // notify::Event, look at src/lib.rs for details.

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -219,13 +219,13 @@ impl Watcher for FsEventWatcher {
     Ok(fsevent)
   }
 
-  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn watch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     self.stop();
     self.append_path(&path.as_ref().to_str().unwrap());
     self.run()
   }
 
-  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     self.stop();
     self.remove_path(&path.as_ref().to_str().unwrap());
     // ignore return error: may be empty path list

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -252,12 +252,12 @@ fn test_fsevent_watcher_drop() {
 
   {
     let mut watcher: RecommendedWatcher = Watcher::new(tx).unwrap();
-    watcher.watch(&Path::new("../../")).unwrap();
+    watcher.watch("../../").unwrap();
     thread::sleep_ms(2_000);
     println!("is running -> {}", watcher.is_running());
 
     thread::sleep_ms(1_000);
-    watcher.unwatch(&Path::new("../..")).unwrap();
+    watcher.unwatch("../..").unwrap();
     println!("is running -> {}", watcher.is_running());
   }
 

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -219,15 +219,15 @@ impl Watcher for FsEventWatcher {
     Ok(fsevent)
   }
 
-  fn watch(&mut self, path: &Path) -> Result<(), Error> {
+  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
     self.stop();
-    self.append_path(&path.to_str().unwrap());
+    self.append_path(&path.as_ref().to_str().unwrap());
     self.run()
   }
 
-  fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
     self.stop();
-    self.remove_path(&path.to_str().unwrap());
+    self.remove_path(&path.as_ref().to_str().unwrap());
     // ignore return error: may be empty path list
     let _ = self.run();
     Ok(())

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -130,13 +130,13 @@ impl Watcher for INotifyWatcher {
     return Ok(it);
   }
 
-  fn watch(&mut self, path: &Path) -> Result<(), Error> {
-    let is_dir = match metadata(&path) {
+  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+    let is_dir = match metadata(&path.as_ref()) {
       Ok(m)  => m.is_dir(),
       Err(e) => return Err(Error::Io(e)),
     };
     if is_dir {
-      match Walker::new(path) {
+      match Walker::new(path.as_ref()) {
         Ok(dir) => {
           for entry in dir {
             match entry {
@@ -147,20 +147,20 @@ impl Watcher for INotifyWatcher {
               Err(e) => return Err(Error::Io(e)),
             }
           }
-          self.add_watch(path)
+          self.add_watch(path.as_ref())
         },
         Err(e) => Err(Error::Io(e))
       }
     } else {
-      self.add_watch(&path)
+      self.add_watch(&path.as_ref())
     }
   }
 
-  fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
     // FIXME:
     // once Rust 1.1 is released, just use a &Path
     // Relevant bug is https://github.com/rust-lang/rust/pull/25060
-    match self.watches.remove(&path.to_path_buf()) {
+    match self.watches.remove(&path.as_ref().to_path_buf()) {
       None => Err(Error::WatchNotFound),
       Some(p) => {
         let w = &p.0;

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -49,7 +49,7 @@ impl INotifyWatcher {
     });
   }
 
-  fn add_watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn add_watch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     let mut watching  = flags::IN_ATTRIB
                       | flags::IN_CREATE
                       | flags::IN_DELETE
@@ -130,7 +130,7 @@ impl Watcher for INotifyWatcher {
     return Ok(it);
   }
 
-  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn watch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     let is_dir = match metadata(&path.as_ref()) {
       Ok(m)  => m.is_dir(),
       Err(e) => return Err(Error::Io(e)),
@@ -156,7 +156,7 @@ impl Watcher for INotifyWatcher {
     }
   }
 
-  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     // FIXME:
     // once Rust 1.1 is released, just use a &Path
     // Relevant bug is https://github.com/rust-lang/rust/pull/25060

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -49,7 +49,7 @@ impl INotifyWatcher {
     });
   }
 
-  fn add_watch(&mut self, path: &Path) -> Result<(), Error> {
+  fn add_watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
     let mut watching  = flags::IN_ATTRIB
                       | flags::IN_CREATE
                       | flags::IN_DELETE
@@ -58,7 +58,7 @@ impl INotifyWatcher {
                       | flags::IN_MOVED_FROM
                       | flags::IN_MOVED_TO
                       | flags::IN_MOVE_SELF;
-    let path = path.to_path_buf();
+    let path = path.as_ref().to_path_buf();
     match self.watches.get(&path) {
       None => {},
       Some(p) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use self::op::Op;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
+use std::convert::AsRef;
 
 #[cfg(target_os="macos")] pub use self::fsevent::FsEventWatcher;
 #[cfg(target_os="linux")] pub use self::inotify::INotifyWatcher;
@@ -49,8 +50,8 @@ pub enum Error {
 
 pub trait Watcher {
   fn new(Sender<Event>) -> Result<Self, Error>;
-  fn watch(&mut self, &Path) -> Result<(), Error>;
-  fn unwatch(&mut self, &Path) -> Result<(), Error>;
+  fn watch<P: AsRef<Path>>(&mut self, P) -> Result<(), Error>;
+  fn unwatch<P: AsRef<Path>>(&mut self, P) -> Result<(), Error>;
 }
 
 #[cfg(target_os = "linux")] pub type RecommendedWatcher = INotifyWatcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ pub enum Error {
 
 pub trait Watcher {
   fn new(Sender<Event>) -> Result<Self, Error>;
-  fn watch<P: AsRef<Path>>(&mut self, P) -> Result<(), Error>;
-  fn unwatch<P: AsRef<Path>>(&mut self, P) -> Result<(), Error>;
+  fn watch<P: AsRef<Path> + ?Sized>(&mut self, &P) -> Result<(), Error>;
+  fn unwatch<P: AsRef<Path> + ?Sized>(&mut self, &P) -> Result<(), Error>;
 }
 
 #[cfg(target_os = "linux")] pub type RecommendedWatcher = INotifyWatcher;

--- a/src/null.rs
+++ b/src/null.rs
@@ -11,11 +11,11 @@ impl Watcher for NullWatcher {
     Ok(NullWatcher)
   }
 
-  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn watch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     Ok(())
   }
 
-  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     Ok(())
   }
 }

--- a/src/null.rs
+++ b/src/null.rs
@@ -11,11 +11,11 @@ impl Watcher for NullWatcher {
     Ok(NullWatcher)
   }
 
-  fn watch(&mut self, path: &Path) -> Result<(), Error> {
+  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
     Ok(())
   }
 
-  fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
     Ok(())
   }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -146,12 +146,12 @@ impl Watcher for PollWatcher {
     Ok(p)
   }
 
-  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn watch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     (*self.watches).write().unwrap().insert(path.as_ref().to_path_buf());
     Ok(())
   }
 
-  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+  fn unwatch<P: AsRef<Path> + ?Sized>(&mut self, path: &P) -> Result<(), Error> {
     if (*self.watches).write().unwrap().remove(path.as_ref()) {
       Ok(())
     } else {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -146,13 +146,13 @@ impl Watcher for PollWatcher {
     Ok(p)
   }
 
-  fn watch(&mut self, path: &Path) -> Result<(), Error> {
-    (*self.watches).write().unwrap().insert(path.to_path_buf());
+  fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+    (*self.watches).write().unwrap().insert(path.as_ref().to_path_buf());
     Ok(())
   }
 
-  fn unwatch(&mut self, path: &Path) -> Result<(), Error> {
-    if (*self.watches).write().unwrap().remove(path) {
+  fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+    if (*self.watches).write().unwrap().remove(path.as_ref()) {
       Ok(())
     } else {
       Err(Error::WatchNotFound)


### PR DESCRIPTION
This should be a non-breaking change and it removes the need to call `Path::new` when calling `watch` or `unwatch`. This means `watcher.watch("/tmp/foo")` is now valid.