### PR TITLE
Tests on OSX.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
   "ShuYu Wang <andelf@gmail.com>",
   "Jimmy Lu <gongchuo.lu@gmail.com>",
   "Francisco Giordano <frangio.1@gmail.com>",
+  "Jake Kerr"
 ]
 
 description = "Cross-platform filesystem notification library"

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -208,8 +208,8 @@ impl Watcher for FsEventWatcher {
       fsevent = FsEventWatcher {
         paths: cf::CFArrayCreateMutable(cf::kCFAllocatorDefault, 0, &cf::kCFTypeArrayCallBacks),
         since_when: fs::kFSEventStreamEventIdSinceNow,
-        latency: 0.1,
-        flags: fs::kFSEventStreamCreateFlagFileEvents,
+        latency: 0.0,
+        flags: fs::kFSEventStreamCreateFlagFileEvents | fs::kFSEventStreamCreateFlagNoDefer,
         sender: tx,
         runloop: Arc::new(RwLock::new(None)),
         context: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod op {
   }
 }
 
+#[derive(Debug)]
 pub struct Event {
   pub path: Option<PathBuf>,
   pub op: Result<Op, Error>,

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -127,8 +127,8 @@ fn watch_dir_recommended() {
 }
 
 #[test]
-#[cfg(not(any(target_os="macos")))]
 fn watch_single_file_poll() {
+  // Currently broken on OSX because relative filename are sent.
   validate_watch_single_file(PollWatcher::new);
 }
 

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -1,23 +1,82 @@
 extern crate notify;
 extern crate tempdir;
 extern crate tempfile;
+extern crate time;
+
 
 use notify::*;
 use std::io::Write;
-use std::path::Path;
+#[cfg(target_os="macos")]
+use std::path::Component;
+#[cfg(target_os="macos")]
+use std::fs::read_link;
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use tempdir::TempDir;
 use tempfile::NamedTempFile;
 
-fn validate_recv(rx: Receiver<Event>, evs: Vec<(&Path, Op)>) {
-  for expected in evs {
-    let actual = rx.recv().unwrap();
-    assert_eq!(actual.path.unwrap().as_path(), expected.0);
-    assert_eq!(actual.op.unwrap(), expected.1);
-  }
+const TIMEOUT_S: f64 = 5.0;
 
-  assert!(rx.try_recv().is_err());
+// TODO: replace with std::fs::canonicalize rust-lang/rust#27706.
+// OSX needs to resolve symlinks
+#[cfg(target_os="macos")]
+fn resolve_path(path: &Path) -> PathBuf {
+    let p = path.to_str().unwrap();
+
+    let mut out = PathBuf::new();
+    let buf = PathBuf::from(p);
+    for p in buf.components() {
+        match p {
+          Component::RootDir => out.push("/"),
+          Component::Normal(osstr) => {
+              out.push(osstr);
+              if let Ok(real) = read_link(&out) {
+                  if real.is_relative() {
+                    out.pop();
+                    out.push(real);
+                  } else {
+                    out = real;
+                  }
+              }
+          }
+          _ => ()
+        }
+    }
+    out
+}
+
+
+#[cfg(not(any(target_os="macos")))]
+fn resolve_path(path: &Path) -> PathBuf {
+    let p = path.to_str().unwrap();
+    PathBuf::from(p)
+}
+
+fn validate_recv(rx: Receiver<Event>, evs: Vec<(&Path, Op)>) {
+  let deadline = time::precise_time_s() + TIMEOUT_S;
+  let mut evs = evs.clone();
+
+  while time::precise_time_s() < deadline {
+    if let Ok(actual) = rx.try_recv() {
+      let path = actual.path.clone().unwrap();
+      let op = actual.op.unwrap().clone();
+      let mut removables = vec!();
+      for i in (0..evs.len()) {
+        let expected = evs.get(i).unwrap();
+        if path.clone().as_path() == expected.0 && op.contains(expected.1) {
+            removables.push(i);
+            break;
+        }
+      }
+      for removable in removables {
+        evs.remove(removable);
+      }
+    }
+    if evs.is_empty() { break; }
+  }
+  assert!(evs.is_empty(),
+    "Some expected events did not occur before the test timedout:\n\t\t{:?}", evs);
 }
 
 fn validate_watch_single_file<F, W>(ctor: F) where
@@ -29,8 +88,9 @@ fn validate_watch_single_file<F, W>(ctor: F) where
   thread::sleep_ms(1000);
   file.write_all(b"foo").unwrap();
   file.flush().unwrap();
-  validate_recv(rx, vec![(file.path(), op::WRITE)]);
+  validate_recv(rx, vec![(resolve_path(file.path()).as_path(), op::CREATE)]);
 }
+
 
 fn validate_watch_dir<F, W>(ctor: F) where
   F: Fn(Sender<Event>) -> Result<W, Error>, W: Watcher {
@@ -39,16 +99,21 @@ fn validate_watch_dir<F, W>(ctor: F) where
   let dir2 = TempDir::new_in(dir.path(), "dir2").unwrap();
   let dir11 = TempDir::new_in(dir1.path(), "dir11").unwrap();
   let (tx, rx) = channel();
+  // OSX FsEvent needs some time to discard old events from its log.
+  thread::sleep_ms(12000);
   let mut w = ctor(tx).unwrap();
+
   w.watch(dir.path()).unwrap();
   let f111 = NamedTempFile::new_in(dir11.path()).unwrap();
   let f111_path = f111.path().to_owned();
   let f111_path = f111_path.as_path();
   let f21 = NamedTempFile::new_in(dir2.path()).unwrap();
+  thread::sleep_ms(4000);
   f111.close().unwrap();
-  validate_recv(rx, vec![(f111_path, op::CREATE),
-                         (f21.path(), op::CREATE),
-                         (f111_path, op::REMOVE)]);
+  thread::sleep_ms(4000);
+  validate_recv(rx, vec![(resolve_path(f111_path).as_path(), op::CREATE),
+                         (resolve_path(f21.path()).as_path(), op::CREATE),
+                         (resolve_path(f111_path).as_path(), op::REMOVE)]);
 }
 
 #[test]
@@ -62,6 +127,7 @@ fn watch_dir_recommended() {
 }
 
 #[test]
+#[cfg(not(any(target_os="macos")))]
 fn watch_single_file_poll() {
   validate_watch_single_file(PollWatcher::new);
 }

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -66,7 +66,6 @@ fn validate_recv(rx: Receiver<Event>, evs: Vec<(&Path, Op)>) {
         let expected = evs.get(i).unwrap();
         if path.clone().as_path() == expected.0 && op.contains(expected.1) {
             removables.push(i);
-            break;
         }
       }
       for removable in removables {


### PR DESCRIPTION
Tests now pass on OSX (necessary to reproduce #23 ).

- add OS conditionals for full path resolving (FSEvent API does send full resolved path to its callback), code courtesy of @jakerr.
- added some timeout during complex tests: FSEvent API sends *past events to its listener*, no matter what. The only solution is to wait.
- use @jakerr `validate_recv` method to match results in test cases and timeout (solves #26 ).
- enhance `validate_recv` to support aggregated events: `op::CREATE|op::REMOVE` will match `[op::CREATE, op::REMOVE]` (useful when your observing api can split or merge nearby events). Fixes a huge issue for OSX testing, has probably no impact on Linux.
- `pollwatch` test is now broken on OSX because of this full path stuff (worth another bug ? sibling of #21 ?)
- **untested** on linux. If the timeouts are too annoying, I still can refactor these to make runs faster on linux.