### PR TITLE
Fix event type in validate_watch_single_file text

### DIFF
--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -87,7 +87,7 @@ fn validate_watch_single_file<F, W>(ctor: F) where
   thread::sleep_ms(1000);
   file.write_all(b"foo").unwrap();
   file.flush().unwrap();
-  validate_recv(rx, vec![(resolve_path(file.path()).as_path(), op::CREATE)]);
+  validate_recv(rx, vec![(resolve_path(file.path()).as_path(), op::WRITE)]);
 }
 
 

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -81,11 +81,12 @@ fn validate_recv(rx: Receiver<Event>, evs: Vec<(&Path, Op)>) {
 fn validate_watch_single_file<F, W>(ctor: F) where
   F: Fn(Sender<Event>) -> Result<W, Error>, W: Watcher {
   let mut file = NamedTempFile::new().unwrap();
+  file.write_all(b"foo").unwrap();
   let (tx, rx) = channel();
   let mut w = ctor(tx).unwrap();
   w.watch(file.path()).unwrap();
   thread::sleep_ms(1000);
-  file.write_all(b"foo").unwrap();
+  file.write_all(b"bar").unwrap();
   file.flush().unwrap();
   validate_recv(rx, vec![(resolve_path(file.path()).as_path(), op::WRITE)]);
 }


### PR DESCRIPTION
Since the file is created before the watcher, and we only write to the existing file while it's being watched, we expect a WRITE event, not a CREATE event.

This fix changes the `watch_single_file_recommended()` test from always failing to intermittently failing
for me on Linux.