### PR TITLE
Replaced hand-rolled with mio-based event loop.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,11 @@ walker = "^1.0.0"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 inotify = "^0.1"
+mio = "^0.5"
 
 [target.x86_64-unknown-linux-musl.dependencies]
 inotify = "^0.1"
+mio = "^0.5"
 
 [target.x86_64-apple-darwin.dependencies]
 fsevent = "^0.2.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate bitflags;
+#[cfg(target_os="linux")] extern crate mio;
 #[cfg(target_os="macos")] extern crate fsevent_sys;
 #[cfg(target_os="windows")] extern crate winapi;
 extern crate libc;


### PR DESCRIPTION
This is a follow-up to #37 and hannobraun/inotify-rs#28. Currently the inotify file descriptor is closed on the thread which drops the `Watcher`, for which the behavior is undefined. With these changes, a message is dispatched to the event loop, causing it to shut itself down.