### PR TITLE
Teach cargo configuration about musl libc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ walker = "^1.0.0"
 [target.x86_64-unknown-linux-gnu.dependencies.inotify]
 version = "^0.1"
 
+[target.x86_64-unknown-linux-musl.dependencies.inotify]
+version = "^0.1"
+
 [target.x86_64-apple-darwin.dependencies.fsevent]
 version = "^0.2.11"
 


### PR DESCRIPTION
It's possible to build binaries against a `--target` of `x86_64-unknown-linux-musl`, but unfortunately that doesn't match the current specifier for `x86_64-unknown-linux-gnu`. This patch just teaches cargo about the new configuration.