### PR TITLE
Add missing dependencies on i686

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,15 @@ walkdir = "^0.1"
 inotify = "^0.1"
 mio = "^0.5"
 
+[target.i686-unknown-linux-gnu.dependencies]
+inotify = "^0.1"
+mio = "^0.5"
+
 [target.x86_64-unknown-linux-musl.dependencies]
+inotify = "^0.1"
+mio = "^0.5"
+
+[target.i686-unknown-linux-musl.dependencies]
 inotify = "^0.1"
 mio = "^0.5"
 


### PR DESCRIPTION
Hello,

I tried to build the crate on a GNU/Linux system with a i686 processor and it failed with the following message:

```
   Compiling notify v2.5.2
/home/mrr/.multirust/toolchains/stable/cargo/registry/src/github.com-121aea75f9ef2ce2/notify-2.5.2/src/lib.rs:3:27: 3:44 error: can't find crate for `mio` [E0463]
/home/mrr/.multirust/toolchains/stable/cargo/registry/src/github.com-121aea75f9ef2ce2/notify-2.5.2/src/lib.rs:3 #[cfg(target_os="linux")] extern crate mio;
                                                                                                                                          ^~~~~~~~~~~~~~~~~
error: aborting due to previous error
```

I added the missing dependencies in `Cargo.toml`, and now it works.