### PR TITLE
feat: display formatted errors.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
 use std::convert::AsRef;
 use std::fmt;
-// Permits retrieve err.description()
 use std::error::Error as StdError;
 
 #[cfg(target_os="macos")] pub use self::fsevent::FsEventWatcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,17 +56,17 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let error = String::from(match *self {
-            Error::PathNotFound => "No path was found.",
-            Error::WatchNotFound => "No watch was found.",
-            Error::NotImplemented => "Not implemented.",
-            Error::Generic(ref err) => err.as_ref(),
-            Error::Io(ref err) => err.description(),
-        });
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    let error = String::from(match *self {
+      Error::PathNotFound => "No path was found.",
+      Error::WatchNotFound => "No watch was found.",
+      Error::NotImplemented => "Not implemented.",
+      Error::Generic(ref err) => err.as_ref(),
+      Error::Io(ref err) => err.description(),
+    });
 
-        write!(f, "{}", error)
-    }
+    write!(f, "{}", error)
+  }
 }
 
 pub trait Watcher: Sized {
@@ -87,13 +87,17 @@ pub fn new(tx: Sender<Event>) -> Result<RecommendedWatcher, Error> {
 
 #[test]
 fn display_formatted_errors() {
-    let expected = "Some error";
-    assert_eq!(expected,
-               format!("{}", Error::Generic(String::from(expected))));
-    assert_eq!(
-        expected,
-        format!("{}",
-            Error::Io(io::Error::new(io::ErrorKind::Other, expected))
-            )
-        );
+  let expected = "Some error";
+
+  assert_eq!(
+    expected,
+    format!("{}", Error::Generic(String::from(expected)))
+  );
+
+  assert_eq!(
+    expected,
+    format!("{}",
+      Error::Io(io::Error::new(io::ErrorKind::Other, expected))
+    )
+  );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
 use std::convert::AsRef;
+use std::fmt;
+// Permits retrieve err.description()
+use std::error::Error as StdError;
 
 #[cfg(target_os="macos")] pub use self::fsevent::FsEventWatcher;
 #[cfg(target_os="linux")] pub use self::inotify::INotifyWatcher;
@@ -53,6 +56,20 @@ pub enum Error {
   WatchNotFound,
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let error = String::from(match *self {
+            Error::PathNotFound => "No path was found.",
+            Error::WatchNotFound => "No watch was found.",
+            Error::NotImplemented => "Not implemented.",
+            Error::Generic(ref err) => err.as_ref(),
+            Error::Io(ref err) => err.description(),
+        });
+
+        write!(f, "{}", error)
+    }
+}
+
 pub trait Watcher: Sized {
   fn new(Sender<Event>) -> Result<Self, Error>;
   fn watch<P: AsRef<Path>>(&mut self, P) -> Result<(), Error>;
@@ -66,4 +83,18 @@ pub trait Watcher: Sized {
 
 pub fn new(tx: Sender<Event>) -> Result<RecommendedWatcher, Error> {
   Watcher::new(tx)
+}
+
+
+#[test]
+fn display_formatted_errors() {
+    let expected = "Some error";
+    assert_eq!(expected,
+               format!("{}", Error::Generic(String::from(expected))));
+    assert_eq!(
+        expected,
+        format!("{}",
+            Error::Io(io::Error::new(io::ErrorKind::Other, expected))
+            )
+        );
 }


### PR DESCRIPTION
Hi there.

I've implemented the trait Display for the enum errors. That way we can display formatted messages for users when necessary instead of the debug version.

Feel free to review.

Cheers!