### PR TITLE
Document the public API

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -1,3 +1,13 @@
+//! Watcher implementation for Darwin's FSEvent API
+//!
+//! The FSEvent API provides a mechanism to notify clients about directories they ought to re-scan
+//! in order to keep their internal data structures up-to-date with respect to the true state of the
+//! file system. (For example, when files or directories are created, modified, or removed.) It
+//! sends these notifications "in bulk", possibly notifying the client of changes to several
+//! directories in a single callback.
+//!
+//! See also https://developer.apple.com/library/mac/documentation/Darwin/Reference/FSEvents_Ref/
+
 #![allow(non_upper_case_globals, dead_code)]
 extern crate fsevent as fse;
 
@@ -16,6 +26,7 @@ use super::{Error, Event, op, Watcher};
 use std::path::{Path, PathBuf};
 use libc;
 
+/// FSEvent-based `Watcher` implementation
 pub struct FsEventWatcher {
     paths: cf::CFMutableArrayRef,
     since_when: fs::FSEventStreamEventId,
@@ -53,10 +64,14 @@ struct StreamContextInfo {
 
 impl FsEventWatcher {
     #[inline]
+    #[doc(hidden)]
+    // TODO should not be pub
     pub fn is_running(&self) -> bool {
         self.runloop.is_some()
     }
 
+    #[doc(hidden)]
+    // TODO should not be pub
     pub fn stop(&mut self) {
         if !self.is_running() {
             return;
@@ -104,6 +119,8 @@ impl FsEventWatcher {
         }
     }
 
+    #[doc(hidden)]
+    // TODO should not be pub
     pub fn run(&mut self) -> Result<(), Error> {
         if unsafe { cf::CFArrayGetCount(self.paths) } == 0 {
             return Err(Error::PathNotFound);
@@ -171,6 +188,7 @@ impl FsEventWatcher {
 }
 
 #[allow(unused_variables)]
+#[doc(hidden)]
 pub unsafe extern "C" fn callback(
   stream_ref: fs::FSEventStreamRef,
   info: *mut libc::c_void,

--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -1,3 +1,9 @@
+//! Watcher implementation for the inotify Linux API
+//!
+//! The inotify API provides a mechanism for monitoring filesystem events.  Inotify can be used to
+//! monitor individual files, or to monitor directories.  When a directory is monitored, inotify
+//! will return events for the directory itself, and for files inside the directory.
+
 extern crate inotify as inotify_sys;
 extern crate libc;
 extern crate walkdir;
@@ -17,6 +23,7 @@ mod flags;
 
 const INOTIFY: mio::Token = mio::Token(0);
 
+/// Watcher implementation based on inotify
 pub struct INotifyWatcher(mio::Sender<EventLoopMsg>);
 
 struct INotifyHandler {

--- a/src/null.rs
+++ b/src/null.rs
@@ -1,21 +1,26 @@
+//! Stub Watcher implementation
+
 #![allow(unused_variables)]
 
 use std::sync::mpsc::Sender;
 use std::path::Path;
 use super::{Error, Event, Watcher};
 
+/// Stub `Watcher` implementation
+///
+/// Events are never delivered from this watcher.
 pub struct NullWatcher;
 
 impl Watcher for NullWatcher {
-    fn new(tx: Sender<Event>) -> Result<NullWatcher, Error> {
+    fn new(_tx: Sender<Event>) -> Result<NullWatcher, Error> {
         Ok(NullWatcher)
     }
 
-    fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+    fn watch<P: AsRef<Path>>(&mut self, _path: P) -> Result<(), Error> {
         Ok(())
     }
 
-    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
+    fn unwatch<P: AsRef<Path>>(&mut self, _path: P) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,3 +1,8 @@
+//! Generic Watcher implementation based on polling
+//!
+//! Checks the `watch`ed paths periodically to detect changes. This implementation only uses
+//! cross-platform APIs; it should function on any platform that the Rust standard library does.
+
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use std::sync::mpsc::Sender;
@@ -12,6 +17,7 @@ use filetime::FileTime;
 
 extern crate walkdir;
 
+/// Polling based `Watcher` implementation
 pub struct PollWatcher {
     tx: Sender<Event>,
     watches: Arc<RwLock<HashSet<PathBuf>>>,
@@ -19,6 +25,7 @@ pub struct PollWatcher {
 }
 
 impl PollWatcher {
+    /// Create a PollWatcher which polls every `delay` milliseconds
     pub fn with_delay(tx: Sender<Event>, delay: u32) -> Result<PollWatcher, Error> {
         let mut p = PollWatcher {
             tx: tx,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,3 +1,7 @@
+//! Watcher implementation for Windows' directory management APIs
+//!
+//! See https://msdn.microsoft.com/en-us/library/windows/desktop/aa363950(v=vs.85).aspx
+
 extern crate kernel32;
 
 use winapi::{OVERLAPPED, LPOVERLAPPED, HANDLE, INVALID_HANDLE_VALUE, INFINITE, TRUE,


### PR DESCRIPTION
This adds documentation to the public APIs. I tried to highlight any backend specific gotchas in a couple of cases (such as which errors can be generated from where).

There are a few things I found that shouldn't really be part of the public API, but those can't be resolved until a new major version; I'll file another issue to address that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/passcod/rsnotify/65)
<!-- Reviewable:end -->
