### PR TITLE
Add op::IGNORED

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -184,6 +184,9 @@ fn handle_event(event: wrapper::Event,
     if event.is_attrib() {
         o.insert(op::CHMOD);
     }
+    if event.is_ignored() {
+        o.insert(op::IGNORED);
+    }
 
     let path = if event.name.is_empty() {
         match (*paths).read().unwrap().get(&event.wd) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,15 +130,17 @@ pub mod op {
         /// Multiple actions may be delivered in a single event.
         flags Op: u32 {
             /// Permissions changed
-            const CHMOD   = 0b00001,
+            const CHMOD   = 0b000001,
             /// Created
-            const CREATE  = 0b00010,
+            const CREATE  = 0b000010,
             /// Removed
-            const REMOVE  = 0b00100,
+            const REMOVE  = 0b000100,
             /// Renamed
-            const RENAME  = 0b01000,
+            const RENAME  = 0b001000,
             /// Written
-            const WRITE   = 0b10000,
+            const WRITE   = 0b010000,
+            /// Watch has been ignored by the implementation
+            const IGNORED = 0b100000,
         }
     }
 }


### PR DESCRIPTION
inotify sometimes unwatches a file (ignores it) if it's been removed,
and the inotify IGNORED event is generated. This previously presented
itself from rsnotify as an `Op` with no bits set. Now, there is an
IGNORED Op so users can detect it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/passcod/rsnotify/73)
<!-- Reviewable:end -->
