### PR TITLE
Watch only new directories in the monitor example

### DIFF
--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -23,8 +23,10 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
         match rx.recv() {
           Ok(notify::Event{path:Some(path), op:Ok(CREATE)}) => {
               println!("{:?} {:?}", CREATE, path);
-              if let Err(e) = watcher.watch(path) {
-                  println!("error adding watch {}", e);
+              if path.is_dir() {
+                  if let Err(e) = watcher.watch(path) {
+                      println!("error adding watch {}", e);
+                  }
               }
           },
           Ok(notify::Event{path:Some(path), op:Ok(op)}) => {


### PR DESCRIPTION
The current example can be confusing since directories report events for their files anyway.

If the newly created files are watched on top of their parent directory, some events get emitted multiple times and in some cases out of order. Since rsnotify condenses events to only 6 possible values, it can be hard to understand what's going on when monitoring a directory.