### PR TITLE
Refactor and add more tests

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -116,7 +116,7 @@ impl ReadDirectoryChangesServer {
 
             unsafe {
                 // wait with alertable flag so that the completion routine fires
-                let waitres = kernel32::WaitForSingleObjectEx(self.wakeup_sem, 500, TRUE);
+                let waitres = kernel32::WaitForSingleObjectEx(self.wakeup_sem, 100, TRUE);
                 if waitres == WAIT_OBJECT_0 {
                     let _ = self.meta_tx.send(MetaEvent::WatcherAwakened);
                 }
@@ -364,7 +364,7 @@ impl ReadDirectoryChangesWatcher {
 
     fn wakeup_server(&mut self) {
         // breaks the server out of its wait state.  right now this is really just an optimization,
-        // so that if you add a watch you don't block for 500ms in watch() while the
+        // so that if you add a watch you don't block for 100ms in watch() while the
         // server sleeps.
         unsafe {
             kernel32::ReleaseSemaphore(self.wakeup_sem, 1, ptr::null_mut());


### PR DESCRIPTION
I have started to write some tests. They are not complete and not all tests succeed. I disabled ("ignored") the ones that don't work for now. And I would like to add some more tests, so this is just the first batch.

~~I set up VMs with windows and os x to test it and there are quite a few differences on various platforms. In order to deal with all the minor differences I had to use a lot of conditionally compiled asserts. To simplify things I use the stmt_expr_attributes feature, which requires rust nightly.~~

~~I also changed the Windows FILE_ACTION_RENAMED_NEW_NAME event from RENAME to CREATE event in order to match the Linux behavior. This is a breaking change, so I set the version number to 3.0.0. I didn't find a changelog file though.~~