### PR TITLE
Translate Windows FILE_ACTION_RENAMED_NEW_NAME events to CREATE events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify"
-version = "2.6.1"
+version = "3.0.0"
 authors = [
   "Félix Saparelli <me@passcod.name>",
   "Jorge Israel Peña <jorge.israel.p@gmail.com>",

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -310,11 +310,11 @@ unsafe extern "system" fn handle_event(error_code: u32,
 
         if !skip {
             let op = match (*cur_entry).Action {
-                winnt::FILE_ACTION_ADDED => op::CREATE,
+                winnt::FILE_ACTION_ADDED |
+                winnt::FILE_ACTION_RENAMED_NEW_NAME => op::CREATE,
                 winnt::FILE_ACTION_REMOVED => op::REMOVE,
                 winnt::FILE_ACTION_MODIFIED => op::WRITE,
-                winnt::FILE_ACTION_RENAMED_OLD_NAME |
-                winnt::FILE_ACTION_RENAMED_NEW_NAME => op::RENAME,
+                winnt::FILE_ACTION_RENAMED_OLD_NAME => op::RENAME,
                 _ => Op::empty(),
             };
 


### PR DESCRIPTION
Translate Windows FILE_ACTION_RENAMED_NEW_NAME events to CREATE events in order to match the Linux behavior.