### PR TITLE
Normalize the recursive watch behavior of the various back-ends

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -102,7 +102,7 @@ impl mio::Handler for INotifyHandler {
     }
 }
 
-/// return DirEntry when it is a directory
+/// return `DirEntry` when it is a directory
 fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry> {
     if let Ok(e) = e {
         if let Ok(metadata) = e.metadata() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub mod op {
 /// When using the poll watcher, `op` may be Err in the case where getting metadata for the path
 /// fails.
 ///
-/// When using the INotifyWatcher, `op` may be Err if activity is detected on the file and there is
+/// When using the `INotifyWatcher`, `op` may be Err if activity is detected on the file and there is
 /// an error reading from inotify.
 #[derive(Debug)]
 pub struct Event {
@@ -200,7 +200,7 @@ impl fmt::Display for Error {
     }
 }
 
-/// Type alias to use this library's Error type in a Result
+/// Type alias to use this library's `Error` type in a Result
 pub type Result<T> = StdResult<T, Error>;
 
 impl StdError for Error {
@@ -247,19 +247,26 @@ impl RecursiveMode {
 /// addition to such event driven implementations, a polling implementation is also provided that
 /// should work on any platform.
 pub trait Watcher: Sized {
-    /// Create a new Watcher
-    fn new(Sender<Event>) -> Result<Self>;
-
-    /// Begin watching a new path
+    /// Create a new Watcher.
     ///
-    /// If the path is a directory, events will be delivered for all files in that tree.
-    fn watch<P: AsRef<Path>>(&mut self, P, RecursiveMode) -> Result<()>;
+    /// Events will be sent using the provided `tx`.
+    fn new(tx: Sender<Event>) -> Result<Self>;
 
-    /// Stop watching a path
+    /// Begin watching a new path.
     ///
-    /// Returns an Error in the case that Path has not been watched or if failing to remove the
-    /// watch fails.
-    fn unwatch<P: AsRef<Path>>(&mut self, P) -> Result<()>;
+    /// If the `path` is a directory, `recursive_mode` will be evaluated.
+    /// If `recursive_mode` is `RecursiveMode::Recursive` events will be delivered for all files in that tree.
+    /// Otherwise only the directory and it's immediate children will be watched.
+    ///
+    /// If the `path` is a file, `recursive_mode` will be ignored and events will be delivered only for the file.
+    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()>;
+
+    /// Stop watching a path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error in the case that `path` has not been watched or if removing the watch fails.
+    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()>;
 }
 
 /// The recommended `Watcher` implementation for the current platform
@@ -275,7 +282,9 @@ pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 pub type RecommendedWatcher = PollWatcher;
 
-/// Convenience method for creating the `RecommendedWatcher` for the current platform
+/// Convenience method for creating the `RecommendedWatcher` for the current platform.
+///
+/// Events will be sent using the provided `tx`.
 pub fn new(tx: Sender<Event>) -> Result<RecommendedWatcher> {
     Watcher::new(tx)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```no_run
 //! extern crate notify;
 //!
-//! use notify::{RecommendedWatcher, Error, Watcher};
+//! use notify::{RecommendedWatcher, Error, Watcher, RecursiveMode};
 //! use std::sync::mpsc::channel;
 //!
 //! fn main() {
@@ -33,7 +33,7 @@
 //!     Ok(mut watcher) => {
 //!       // Add a path to be watched. All files and directories at that path and
 //!       // below will be monitored for changes.
-//!       watcher.watch("/home/test/notify");
+//!       watcher.watch("/home/test/notify", RecursiveMode::Recursive);
 //!
 //!       // You'll probably want to do that in a loop. The type to match for is
 //!       // notify::Event, look at src/lib.rs for details.
@@ -222,6 +222,25 @@ impl StdError for Error {
     }
 }
 
+/// Indicates whether only the provided directory or its sub-directories as well should be watched
+#[derive(Debug)]
+pub enum RecursiveMode {
+    /// Watch all sub-directories as well, including directories created after installing the watch
+    Recursive,
+
+    /// Watch only the provided directory
+    NonRecursive,
+}
+
+impl RecursiveMode {
+    fn is_recursive(&self) -> bool  {
+        match *self {
+            RecursiveMode::Recursive => true,
+            RecursiveMode::NonRecursive => false,
+        }
+    }
+}
+
 /// Type that can deliver file activity notifications
 ///
 /// Watcher is implemented per platform using the best implementation available on that platform. In
@@ -234,7 +253,7 @@ pub trait Watcher: Sized {
     /// Begin watching a new path
     ///
     /// If the path is a directory, events will be delivered for all files in that tree.
-    fn watch<P: AsRef<Path>>(&mut self, P) -> Result<()>;
+    fn watch<P: AsRef<Path>>(&mut self, P, RecursiveMode) -> Result<()>;
 
     /// Stop watching a path
     ///

--- a/src/null.rs
+++ b/src/null.rs
@@ -4,7 +4,7 @@
 
 use std::sync::mpsc::Sender;
 use std::path::Path;
-use super::{Event, Result, Watcher};
+use super::{Event, Result, Watcher, RecursiveMode};
 
 /// Stub `Watcher` implementation
 ///
@@ -16,7 +16,7 @@ impl Watcher for NullWatcher {
         Ok(NullWatcher)
     }
 
-    fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
         Ok(())
     }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -3,7 +3,7 @@
 //! Checks the `watch`ed paths periodically to detect changes. This implementation only uses
 //! cross-platform APIs; it should function on any platform that the Rust standard library does.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::sync::mpsc::Sender;
 use std::fs;
@@ -16,11 +16,12 @@ use self::walkdir::WalkDir;
 use filetime::FileTime;
 
 extern crate walkdir;
+extern crate time;
 
 /// Polling based `Watcher` implementation
 pub struct PollWatcher {
     tx: Sender<Event>,
-    watches: Arc<RwLock<HashSet<PathBuf>>>,
+    watches: Arc<RwLock<HashMap<PathBuf, bool>>>,
     open: Arc<RwLock<bool>>,
 }
 
@@ -29,7 +30,7 @@ impl PollWatcher {
     pub fn with_delay(tx: Sender<Event>, delay: u32) -> Result<PollWatcher> {
         let mut p = PollWatcher {
             tx: tx,
-            watches: Arc::new(RwLock::new(HashSet::new())),
+            watches: Arc::new(RwLock::new(HashMap::new())),
             open: Arc::new(RwLock::new(true)),
         };
         p.run(delay);
@@ -42,32 +43,66 @@ impl PollWatcher {
         let open = self.open.clone();
         thread::spawn(move || {
             // In order of priority:
-            // TODO: populate mtimes before loop, and then handle creation events
-            // TODO: handle deletion events
             // TODO: handle chmod events
             // TODO: handle renames
             // TODO: DRY it up
-            let mut mtimes: HashMap<PathBuf, u64> = HashMap::new();
-            loop {
-                if delay != 0 {
-                    thread::sleep(Duration::from_millis(delay as u64));
+            let mut mtimes: HashMap<PathBuf, (u64, f64)> = HashMap::new();
+
+            let mut current_time = time::precise_time_s();
+
+            for (watch, is_recursive) in watches.read().unwrap().iter() {
+                match fs::metadata(watch) {
+                    Err(e) => {
+                        let _ = tx.send(Event {
+                            path: Some(watch.clone()),
+                            op: Err(Error::Io(e)),
+                        });
+                        continue;
+                    }
+                    Ok(metadata) => {
+                        if !metadata.is_dir() {
+                            let modified = FileTime::from_last_modification_time(&metadata).seconds();
+                            mtimes.insert(watch.clone(), (modified, current_time));
+                        } else {
+                            let depth = if *is_recursive {
+                                usize::max_value()
+                            } else {
+                                1
+                            };
+                            for entry in WalkDir::new(watch)
+                                                .follow_links(true)
+                                                .max_depth(depth)
+                                                .into_iter()
+                                                .filter_map(|e| e.ok()) {
+                                let path = entry.path();
+
+                                match entry.metadata() {
+                                    Err(e) => {
+                                        let _ = tx.send(Event {
+                                            path: Some(path.to_path_buf()),
+                                            op: Err(Error::Io(e.into())),
+                                        });
+                                    }
+                                    Ok(m) => {
+                                        let modified = FileTime::from_last_modification_time(&m).seconds();
+                                        mtimes.insert(path.to_path_buf(), (modified, current_time));
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
+            }
+
+            loop {
                 if !(*open.read().unwrap()) {
                     break;
                 }
 
-                for watch in watches.read().unwrap().iter() {
-                    let meta = fs::metadata(watch);
+                current_time = time::precise_time_s();
 
-                    if !meta.is_ok() {
-                        let _ = tx.send(Event {
-                            path: Some(watch.clone()),
-                            op: Err(Error::PathNotFound),
-                        });
-                        continue;
-                    }
-
-                    match meta {
+                for (watch, is_recursive) in watches.read().unwrap().iter() {
+                    match fs::metadata(watch) {
                         Err(e) => {
                             let _ = tx.send(Event {
                                 path: Some(watch.clone()),
@@ -75,61 +110,93 @@ impl PollWatcher {
                             });
                             continue;
                         }
-                        Ok(stat) => {
-                            let modified = FileTime::from_last_modification_time(&stat).seconds();
-
-                            match mtimes.insert(watch.clone(), modified) {
-                                None => continue, // First run
-                                Some(old) => {
-                                    if modified > old {
-                                        let _ = tx.send(Event {
-                                            path: Some(watch.clone()),
-                                            op: Ok(op::WRITE),
-                                        });
-                                        continue;
+                        Ok(metadata) => {
+                            if !metadata.is_dir() {
+                                let modified = FileTime::from_last_modification_time(&metadata).seconds();
+                                match mtimes.insert(watch.clone(), (modified, current_time)) {
+                                    None => {
+                                        unreachable!();
                                     }
-                                }
-                            }
-
-                            if !stat.is_dir() {
-                                continue;
-                            }
-                        }
-                    }
-
-                    // TODO: more efficient implementation where the dir tree is cached?
-                    for entry in WalkDir::new(watch)
-                                     .follow_links(true)
-                                     .into_iter()
-                                     .filter_map(|e| e.ok()) {
-                        let path = entry.path();
-
-                        match fs::metadata(&path) {
-                            Err(e) => {
-                                let _ = tx.send(Event {
-                                    path: Some(path.to_path_buf()),
-                                    op: Err(Error::Io(e)),
-                                });
-                                continue;
-                            }
-                            Ok(stat) => {
-                                let modified = FileTime::from_last_modification_time(&stat)
-                                                   .seconds();
-                                match mtimes.insert(path.to_path_buf(), modified) {
-                                    None => continue, // First run
-                                    Some(old) => {
-                                        if modified > old {
+                                    Some((old_modified, _)) => {
+                                        if modified > old_modified {
                                             let _ = tx.send(Event {
-                                                path: Some(path.to_path_buf()),
+                                                path: Some(watch.clone()),
                                                 op: Ok(op::WRITE),
                                             });
-                                            continue;
+                                        }
+                                    }
+                                }
+                            } else {
+                                let depth = if *is_recursive {
+                                    usize::max_value()
+                                } else {
+                                    1
+                                };
+                                for entry in WalkDir::new(watch)
+                                                    .follow_links(true)
+                                                    .max_depth(depth)
+                                                    .into_iter()
+                                                    .filter_map(|e| e.ok()) {
+                                    let path = entry.path();
+
+                                    match entry.metadata() {
+                                        Err(e) => {
+                                            let _ = tx.send(Event {
+                                                path: Some(path.to_path_buf()),
+                                                op: Err(Error::Io(e.into())),
+                                            });
+                                        }
+                                        Ok(m) => {
+                                            let modified = FileTime::from_last_modification_time(&m).seconds();
+                                            match mtimes.insert(path.to_path_buf(), (modified, current_time)) {
+                                                None => {
+                                                    let _ = tx.send(Event {
+                                                        path: Some(path.to_path_buf()),
+                                                        op: Ok(op::CREATE),
+                                                    });
+                                                }
+                                                Some((old_modified, _)) => {
+                                                    if modified > old_modified {
+                                                        let _ = tx.send(Event {
+                                                            path: Some(path.to_path_buf()),
+                                                            op: Ok(op::WRITE),
+                                                        });
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
                     }
+                }
+
+                let mut removed: Vec<PathBuf> = Vec::new();
+
+                'paths: for (ref path, &(_, last_checked)) in &mtimes {
+                    for (watch, _) in watches.read().unwrap().iter() {
+                        if path.starts_with(watch) {
+                            if last_checked < current_time {
+                                let _ = tx.send(Event {
+                                    path: Some(path.to_path_buf()),
+                                    op: Ok(op::REMOVE),
+                                });
+                                removed.push(path.to_path_buf());
+                            }
+                            continue 'paths;
+                        }
+                    }
+                    // not found in watches
+                    removed.push(path.to_path_buf());
+                }
+
+                for path in removed {
+                    mtimes.remove(&path);
+                }
+
+                if delay != 0 {
+                    thread::sleep(Duration::from_millis(delay as u64));
                 }
             }
         });
@@ -142,12 +209,12 @@ impl Watcher for PollWatcher {
     }
 
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
-        (*self.watches).write().unwrap().insert(path.as_ref().to_path_buf());
+        (*self.watches).write().unwrap().insert(path.as_ref().to_path_buf(), recursive_mode.is_recursive());
         Ok(())
     }
 
     fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        if (*self.watches).write().unwrap().remove(path.as_ref()) {
+        if (*self.watches).write().unwrap().remove(path.as_ref()).is_some() {
             Ok(())
         } else {
             Err(Error::WatchNotFound)

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -4,7 +4,7 @@
 //! cross-platform APIs; it should function on any platform that the Rust standard library does.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, Mutex};
 use std::sync::mpsc::Sender;
 use std::fs;
 use std::thread;
@@ -18,10 +18,20 @@ use filetime::FileTime;
 extern crate walkdir;
 extern crate time;
 
+struct PathData {
+    mtime: u64,
+    last_check: f64,
+}
+
+struct WatchData {
+    is_recursive: bool,
+    paths: HashMap<PathBuf, PathData>,
+}
+
 /// Polling based `Watcher` implementation
 pub struct PollWatcher {
     tx: Sender<Event>,
-    watches: Arc<RwLock<HashMap<PathBuf, bool>>>,
+    watches: Arc<Mutex<HashMap<PathBuf, WatchData>>>,
     open: Arc<RwLock<bool>>,
 }
 
@@ -30,7 +40,7 @@ impl PollWatcher {
     pub fn with_delay(tx: Sender<Event>, delay: u32) -> Result<PollWatcher> {
         let mut p = PollWatcher {
             tx: tx,
-            watches: Arc::new(RwLock::new(HashMap::new())),
+            watches: Arc::new(Mutex::new(HashMap::new())),
             open: Arc::new(RwLock::new(true)),
         };
         p.run(delay);
@@ -46,121 +56,76 @@ impl PollWatcher {
             // TODO: handle chmod events
             // TODO: handle renames
             // TODO: DRY it up
-            let mut mtimes: HashMap<PathBuf, (u64, f64)> = HashMap::new();
-
-            let mut current_time = time::precise_time_s();
-
-            for (watch, is_recursive) in watches.read().unwrap().iter() {
-                match fs::metadata(watch) {
-                    Err(e) => {
-                        let _ = tx.send(Event {
-                            path: Some(watch.clone()),
-                            op: Err(Error::Io(e)),
-                        });
-                        continue;
-                    }
-                    Ok(metadata) => {
-                        if !metadata.is_dir() {
-                            let modified = FileTime::from_last_modification_time(&metadata).seconds();
-                            mtimes.insert(watch.clone(), (modified, current_time));
-                        } else {
-                            let depth = if *is_recursive {
-                                usize::max_value()
-                            } else {
-                                1
-                            };
-                            for entry in WalkDir::new(watch)
-                                                .follow_links(true)
-                                                .max_depth(depth)
-                                                .into_iter()
-                                                .filter_map(|e| e.ok()) {
-                                let path = entry.path();
-
-                                match entry.metadata() {
-                                    Err(e) => {
-                                        let _ = tx.send(Event {
-                                            path: Some(path.to_path_buf()),
-                                            op: Err(Error::Io(e.into())),
-                                        });
-                                    }
-                                    Ok(m) => {
-                                        let modified = FileTime::from_last_modification_time(&m).seconds();
-                                        mtimes.insert(path.to_path_buf(), (modified, current_time));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
 
             loop {
                 if !(*open.read().unwrap()) {
                     break;
                 }
 
-                current_time = time::precise_time_s();
+                if let Ok(mut watches) = watches.lock() {
+                    let current_time = time::precise_time_s();
 
-                for (watch, is_recursive) in watches.read().unwrap().iter() {
-                    match fs::metadata(watch) {
-                        Err(e) => {
-                            let _ = tx.send(Event {
-                                path: Some(watch.clone()),
-                                op: Err(Error::Io(e)),
-                            });
-                            continue;
-                        }
-                        Ok(metadata) => {
-                            if !metadata.is_dir() {
-                                let modified = FileTime::from_last_modification_time(&metadata).seconds();
-                                match mtimes.insert(watch.clone(), (modified, current_time)) {
-                                    None => {
-                                        unreachable!();
-                                    }
-                                    Some((old_modified, _)) => {
-                                        if modified > old_modified {
-                                            let _ = tx.send(Event {
-                                                path: Some(watch.clone()),
-                                                op: Ok(op::WRITE),
-                                            });
+                    for (watch, &mut WatchData{is_recursive, ref mut paths}) in watches.iter_mut() {
+                        match fs::metadata(watch) {
+                            Err(e) => {
+                                let _ = tx.send(Event {
+                                    path: Some(watch.clone()),
+                                    op: Err(Error::Io(e)),
+                                });
+                                continue;
+                            }
+                            Ok(metadata) => {
+                                if !metadata.is_dir() {
+                                    let mtime = FileTime::from_last_modification_time(&metadata).seconds();
+                                    match paths.insert(watch.clone(), PathData{mtime: mtime, last_check: current_time}) {
+                                        None => {
+                                            unreachable!();
+                                        }
+                                        Some(PathData{mtime: old_mtime, ..}) => {
+                                            if mtime > old_mtime {
+                                                let _ = tx.send(Event {
+                                                    path: Some(watch.clone()),
+                                                    op: Ok(op::WRITE),
+                                                });
+                                            }
                                         }
                                     }
-                                }
-                            } else {
-                                let depth = if *is_recursive {
-                                    usize::max_value()
                                 } else {
-                                    1
-                                };
-                                for entry in WalkDir::new(watch)
-                                                    .follow_links(true)
-                                                    .max_depth(depth)
-                                                    .into_iter()
-                                                    .filter_map(|e| e.ok()) {
-                                    let path = entry.path();
+                                    let depth = if is_recursive {
+                                        usize::max_value()
+                                    } else {
+                                        1
+                                    };
+                                    for entry in WalkDir::new(watch)
+                                                        .follow_links(true)
+                                                        .max_depth(depth)
+                                                        .into_iter()
+                                                        .filter_map(|e| e.ok()) {
+                                        let path = entry.path();
 
-                                    match entry.metadata() {
-                                        Err(e) => {
-                                            let _ = tx.send(Event {
-                                                path: Some(path.to_path_buf()),
-                                                op: Err(Error::Io(e.into())),
-                                            });
-                                        }
-                                        Ok(m) => {
-                                            let modified = FileTime::from_last_modification_time(&m).seconds();
-                                            match mtimes.insert(path.to_path_buf(), (modified, current_time)) {
-                                                None => {
-                                                    let _ = tx.send(Event {
-                                                        path: Some(path.to_path_buf()),
-                                                        op: Ok(op::CREATE),
-                                                    });
-                                                }
-                                                Some((old_modified, _)) => {
-                                                    if modified > old_modified {
+                                        match entry.metadata() {
+                                            Err(e) => {
+                                                let _ = tx.send(Event {
+                                                    path: Some(path.to_path_buf()),
+                                                    op: Err(Error::Io(e.into())),
+                                                });
+                                            }
+                                            Ok(m) => {
+                                                let mtime = FileTime::from_last_modification_time(&m).seconds();
+                                                match paths.insert(path.to_path_buf(), PathData{mtime: mtime, last_check: current_time}) {
+                                                    None => {
                                                         let _ = tx.send(Event {
                                                             path: Some(path.to_path_buf()),
-                                                            op: Ok(op::WRITE),
+                                                            op: Ok(op::CREATE),
                                                         });
+                                                    }
+                                                    Some(PathData{mtime: old_mtime, ..}) => {
+                                                        if mtime > old_mtime {
+                                                            let _ = tx.send(Event {
+                                                                path: Some(path.to_path_buf()),
+                                                                op: Ok(op::WRITE),
+                                                            });
+                                                        }
                                                     }
                                                 }
                                             }
@@ -170,33 +135,26 @@ impl PollWatcher {
                             }
                         }
                     }
-                }
 
-                let mut removed: Vec<PathBuf> = Vec::new();
-
-                'paths: for (ref path, &(_, last_checked)) in &mtimes {
-                    for (watch, _) in watches.read().unwrap().iter() {
-                        if path.starts_with(watch) {
-                            if last_checked < current_time {
+                    for (_, &mut WatchData{ref mut paths, ..}) in watches.iter_mut() {
+                        let mut removed = Vec::new();
+                        for (path, &PathData{last_check, ..}) in paths.iter() {
+                            if last_check < current_time {
                                 let _ = tx.send(Event {
-                                    path: Some(path.to_path_buf()),
+                                    path: Some(path.clone()),
                                     op: Ok(op::REMOVE),
                                 });
-                                removed.push(path.to_path_buf());
+                                removed.push(path.clone());
                             }
-                            continue 'paths;
+                        }
+                        for path in removed {
+                            (*paths).remove(&path);
                         }
                     }
-                    // not found in watches
-                    removed.push(path.to_path_buf());
-                }
 
-                for path in removed {
-                    mtimes.remove(&path);
-                }
-
-                if delay != 0 {
-                    thread::sleep(Duration::from_millis(delay as u64));
+                    if delay != 0 {
+                        thread::sleep(Duration::from_millis(delay as u64));
+                    }
                 }
             }
         });
@@ -209,12 +167,61 @@ impl Watcher for PollWatcher {
     }
 
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
-        (*self.watches).write().unwrap().insert(path.as_ref().to_path_buf(), recursive_mode.is_recursive());
+        if let Ok(mut watches) = self.watches.lock() {
+            let current_time = time::precise_time_s();
+
+            let watch = path.as_ref().to_owned();
+
+            match fs::metadata(path) {
+                Err(e) => {
+                    let _ = self.tx.send(Event {
+                        path: Some(watch.clone()),
+                        op: Err(Error::Io(e)),
+                    });
+                }
+                Ok(metadata) => {
+                    if !metadata.is_dir() {
+                        let mut paths = HashMap::new();
+                        let mtime = FileTime::from_last_modification_time(&metadata).seconds();
+                        paths.insert(watch.clone(), PathData{mtime: mtime, last_check: current_time});
+                        watches.insert(watch, WatchData{is_recursive: recursive_mode.is_recursive(), paths: paths});
+                    } else {
+                        let mut paths = HashMap::new();
+                        let depth = if recursive_mode.is_recursive() {
+                            usize::max_value()
+                        } else {
+                            1
+                        };
+                        for entry in WalkDir::new(watch.clone())
+                                            .follow_links(true)
+                                            .max_depth(depth)
+                                            .into_iter()
+                                            .filter_map(|e| e.ok()) {
+                            let path = entry.path();
+
+                            match entry.metadata() {
+                                Err(e) => {
+                                    let _ = self.tx.send(Event {
+                                        path: Some(path.to_path_buf()),
+                                        op: Err(Error::Io(e.into())),
+                                    });
+                                }
+                                Ok(m) => {
+                                    let mtime = FileTime::from_last_modification_time(&m).seconds();
+                                    paths.insert(path.to_path_buf(), PathData{mtime: mtime, last_check: current_time});
+                                }
+                            }
+                        }
+                        watches.insert(watch, WatchData{is_recursive: recursive_mode.is_recursive(), paths: paths});
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
     fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        if (*self.watches).write().unwrap().remove(path.as_ref()).is_some() {
+        if (*self.watches).lock().unwrap().remove(path.as_ref()).is_some() {
             Ok(())
         } else {
             Err(Error::WatchNotFound)

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, RwLock};
 use std::sync::mpsc::Sender;
 use std::fs;
 use std::thread;
-use super::{Error, Event, op, Result, Watcher};
+use super::{Error, Event, op, Result, Watcher, RecursiveMode};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use self::walkdir::WalkDir;
@@ -141,7 +141,7 @@ impl Watcher for PollWatcher {
         PollWatcher::with_delay(tx, 10)
     }
 
-    fn watch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
         (*self.watches).write().unwrap().insert(path.as_ref().to_path_buf());
         Ok(())
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -163,7 +163,7 @@ impl PollWatcher {
 
 impl Watcher for PollWatcher {
     fn new(tx: Sender<Event>) -> Result<PollWatcher> {
-        PollWatcher::with_delay(tx, 10)
+        PollWatcher::with_delay(tx, 10_000)
     }
 
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -42,7 +42,7 @@ fn validate_watch_single_file<F, W>(ctor: F) where
     // Flushing doesn't help.  So make sure it is closed before we validate.
     let path = {
         let mut file = NamedTempFile::new().unwrap();
-        w.watch(file.path()).unwrap();
+        w.watch(file.path(), RecursiveMode::Recursive).unwrap();
 
         // make some files that should be exlcuded from watch. this works because tempfile creates
         // them all in the same directory.
@@ -97,7 +97,7 @@ fn validate_watch_dir<F, W>(ctor: F) where
         thread::sleep(Duration::from_millis(10));
     }
 
-    w.watch(dir.path()).unwrap();
+    w.watch(dir.path(), RecursiveMode::Recursive).unwrap();
 
     let f111 = NamedTempFile::new_in(dir11.path()).unwrap();
     let f111_path = canonicalize(f111.path());
@@ -158,7 +158,7 @@ fn create_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -187,7 +187,7 @@ fn write_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -221,7 +221,7 @@ fn modify_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -258,7 +258,7 @@ fn delete_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -290,7 +290,7 @@ fn rename_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -335,7 +335,7 @@ fn move_out_create_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(sub_dir1.into_path()).expect("failed to watch directory");
+    watcher.watch(sub_dir1.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -346,7 +346,7 @@ fn move_out_create_file() {
 
     if cfg!(target_os="windows") {
         assert_eq!(recv_events(&rx), vec![
-            (path1a, op::REMOVE),
+            (path1a, op::REMOVE), // windows interprets a move out of the watched directory as a remove
             (path2, op::CREATE)
         ]);
     } else if cfg!(target_os="macos") {
@@ -378,7 +378,7 @@ fn create_write_modify_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -428,7 +428,7 @@ fn create_rename_overwrite_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -477,7 +477,7 @@ fn rename_rename_file() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -514,7 +514,7 @@ fn create_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -544,7 +544,7 @@ fn modify_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -582,7 +582,7 @@ fn delete_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -596,11 +596,9 @@ fn delete_directory() {
         ]);
     } else if cfg!(target_os="linux") {
         assert_eq!(recv_events(&rx), vec![
-            (path.clone(), op::REMOVE), // excessive remove event
             (path.clone(), op::IGNORED),
             (path, op::REMOVE)
         ]);
-        panic!("linux emits an excessive remove event because it is watching for IN_DELETE_SELF");
     } else {
         assert_eq!(recv_events(&rx), vec![
             (path.clone(), op::REMOVE)
@@ -625,7 +623,7 @@ fn rename_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -638,13 +636,6 @@ fn rename_directory() {
             (path1, op::CREATE | op::RENAME),
             (path2, op::RENAME)
         ]);
-    } else if cfg!(target_os="linux") {
-        assert_eq!(recv_events(rx), vec![
-            (path1.clone(), op::RENAME),
-            (path2, op::CREATE),
-            (path1, op::RENAME) // excessive move event
-        ]);
-        panic!("linux emits an excessive move event because it is watching for IN_MOVE_SELF");
     } else {
         assert_eq!(recv_events(&rx), vec![
             (path1, op::RENAME),
@@ -677,7 +668,7 @@ fn move_out_create_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(sub_dir1.into_path()).expect("failed to watch directory");
+    watcher.watch(sub_dir1.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -688,7 +679,7 @@ fn move_out_create_directory() {
 
     if cfg!(target_os="windows") {
         assert_eq!(recv_events(&rx), vec![
-            (path1a, op::REMOVE),
+            (path1a, op::REMOVE), // windows interprets a move out of the watched directory as a remove
             (path2, op::CREATE)
         ]);
     } else if cfg!(target_os="macos") {
@@ -724,7 +715,7 @@ fn create_rename_overwrite_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -750,10 +741,8 @@ fn create_rename_overwrite_directory() {
             (path1, op::RENAME),
             (path2.clone(), op::CREATE),
             (path2.clone(), op::CHMOD),
-            (path2.clone(), op::REMOVE),
             (path2, op::IGNORED),
         ]);
-        panic!("linux emits remove events after file has been overwritten");
     } else {
         unimplemented!();
     }
@@ -778,7 +767,7 @@ fn rename_rename_directory() {
 
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
-    watcher.watch(temp_dir.into_path()).expect("failed to watch directory");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
 
     if cfg!(target_os="windows") {
         thread::sleep(Duration::from_millis(100));
@@ -793,16 +782,6 @@ fn rename_rename_directory() {
             (path2, op::RENAME),
             (path3, op::RENAME)
         ]);
-    } else if cfg!(target_os="linux") {
-        assert_eq!(recv_events(rx), vec![
-            (path1.clone(), op::RENAME),
-            (path2.clone(), op::CREATE),
-            (path1.clone(), op::RENAME), // excessive move event
-            (path2, op::RENAME),
-            (path3, op::CREATE),
-            (path1, op::RENAME), // excessive move event + the path of the watch has not been updated to path3
-        ]);
-        panic!("linux emits an excessive move event because it is watching for IN_MOVE_SELF");
     } else {
         assert_eq!(recv_events(&rx), vec![
             (path1, op::RENAME),

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -10,7 +10,7 @@ const TIMEOUT_S: f64 = 0.1;
 #[cfg(target_os="windows")]
 const TIMEOUT_S: f64 = 3.0; // windows can take a while
 
-pub fn recv_events(rx: Receiver<Event>) ->  Vec<(PathBuf, Op)> {
+pub fn recv_events(rx: &Receiver<Event>) ->  Vec<(PathBuf, Op)> {
     let deadline = time::precise_time_s() + TIMEOUT_S;
 
     let mut evs: Vec<(PathBuf, Op)> = Vec::new();

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,68 @@
+extern crate notify;
+extern crate time;
+
+use notify::*;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+#[cfg(not(target_os="windows"))]
+const TIMEOUT_S: f64 = 0.1;
+#[cfg(target_os="windows")]
+const TIMEOUT_S: f64 = 3.0; // windows can take a while
+
+pub fn recv_events(rx: Receiver<Event>) ->  Vec<(PathBuf, Op)> {
+    let deadline = time::precise_time_s() + TIMEOUT_S;
+
+    let mut evs: Vec<(PathBuf, Op)> = Vec::new();
+
+    while time::precise_time_s() < deadline {
+        match rx.try_recv() {
+            Ok(Event{path: Some(path), op: Ok(op)}) => {
+                evs.push((path, op));
+            },
+            Ok(Event{path: None, ..})  => (),
+            Ok(Event{op: Err(e), ..}) => panic!("unexpected event err: {:?}", e),
+            Err(TryRecvError::Empty) => (),
+            Err(e) => panic!("unexpected channel err: {:?}", e)
+        }
+    }
+    evs
+}
+
+// FSEvent tends to emit events multiple times and aggregate events,
+// so just check that all expected events arrive for each path,
+// and make sure the paths are in the correct order
+#[allow(dead_code)]
+pub fn inflate_events(input: Vec<(PathBuf, Op)>) -> Vec<(PathBuf, Op)> {
+    let mut output = Vec::new();
+    let mut path = None;
+    let mut ops = Op::empty();
+    for (e_p, e_op) in input {
+        let p = match path {
+            Some(p) => p,
+            None => e_p.clone()
+        };
+        if p == e_p {
+            // ops |= e_op;
+            ops = Op::from_bits_truncate(ops.bits() | e_op.bits());
+        } else {
+            output.push((p, ops));
+            ops = e_op;
+        }
+        path = Some(e_p);
+    }
+    if let Some(p) = path {
+        output.push((p, ops));
+    }
+    output
+}
+
+#[cfg(not(target_os="macos"))]
+pub fn canonicalize(path: &Path) -> PathBuf {
+    path.to_owned()
+}
+
+#[cfg(target_os="macos")]
+pub fn canonicalize(path: &Path) -> PathBuf {
+    path.canonicalize().expect("failed to canonalize path").to_owned()
+}

--- a/tests/watcher.rs
+++ b/tests/watcher.rs
@@ -6,7 +6,8 @@ extern crate time;
 mod utils;
 
 use notify::*;
-use std::sync::mpsc::{self, channel};
+use std::io::Write;
+use std::sync::mpsc;
 use tempdir::TempDir;
 use std::fs;
 use std::thread;
@@ -14,39 +15,39 @@ use std::time::Duration;
 
 use utils::*;
 
-#[cfg(target_os = "linux")]
+#[cfg(target_os="linux")]
 #[test]
 fn new_inotify() {
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
     let w: Result<INotifyWatcher> = Watcher::new(tx);
     assert!(w.is_ok());
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_os="macos")]
 #[test]
 fn new_fsevent() {
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
     let w: Result<FsEventWatcher> = Watcher::new(tx);
     assert!(w.is_ok());
 }
 
 #[test]
 fn new_null() {
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
     let w: Result<NullWatcher> = Watcher::new(tx);
     assert!(w.is_ok());
 }
 
 #[test]
 fn new_poll() {
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
     let w: Result<PollWatcher> = Watcher::new(tx);
     assert!(w.is_ok());
 }
 
 #[test]
 fn new_recommended() {
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
     let w: Result<RecommendedWatcher> = Watcher::new(tx);
     assert!(w.is_ok());
 }
@@ -54,7 +55,7 @@ fn new_recommended() {
 // if this test builds, it means RecommendedWatcher is Send.
 #[test]
 fn test_watcher_send() {
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
 
     let mut watcher: RecommendedWatcher = Watcher::new(tx).unwrap();
 
@@ -68,7 +69,7 @@ fn test_watcher_send() {
 fn test_watcher_sync() {
     use std::sync::{ Arc, RwLock };
 
-    let (tx, _) = channel();
+    let (tx, _) = mpsc::channel();
 
     let watcher: RecommendedWatcher = Watcher::new(tx).unwrap();
     let watcher = Arc::new(RwLock::new(watcher));
@@ -77,4 +78,328 @@ fn test_watcher_sync() {
         let mut watcher = watcher.write().unwrap();
         watcher.watch(".", RecursiveMode::Recursive).unwrap();
     }).join().unwrap();
+}
+
+#[test]
+fn watch_recursive_create_directory() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut new_dir = canonicalize(temp_dir.path());
+    new_dir.push("new_dir");
+    let mut file1 = new_dir.clone();
+    file1.push("file1");
+    let mut file2 = new_dir.clone();
+    file2.push("file2");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
+    watcher.watch(temp_dir.path().to_owned(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    fs::create_dir(new_dir.as_path()).expect("failed to create directory");
+    thread::sleep(Duration::from_millis(10));
+    fs::File::create(file1.as_path()).expect("failed to create file");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    watcher.unwatch(temp_dir.into_path()).expect("failed to unwatch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    fs::File::create(file2.as_path()).expect("failed to create file");
+
+    assert_eq!(recv_events(&rx), vec![
+        (new_dir, op::CREATE),
+        (file1, op::CREATE)
+    ]);
+}
+
+#[test]
+#[ignore]
+fn watch_recursive_move() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut sub_dir1a = canonicalize(temp_dir.path());
+    sub_dir1a.push("sub_dir1a");
+    let mut sub_dir1b = canonicalize(temp_dir.path());
+    sub_dir1b.push("sub_dir1b");
+    let mut path1 = canonicalize(temp_dir.path());
+    path1.push("sub_dir1a");
+    path1.push("file1.bin");
+    let mut path2 = canonicalize(temp_dir.path());
+    path2.push("sub_dir1b");
+    path2.push("file2.bin");
+
+    fs::create_dir(sub_dir1a.as_path()).expect("failed to create directory");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    fs::File::create(path1.as_path()).expect("failed to create file");
+    fs::rename(sub_dir1a.as_path(), sub_dir1b.as_path()).expect("failed to rename file");
+    thread::sleep(Duration::from_millis(10));
+    fs::File::create(path2.as_path()).expect("failed to create file");
+
+    let actual = if cfg!(target_os="windows") {
+        // Windows may sneak a write event in there
+        let mut events = recv_events(&rx);
+        events.retain(|&(_, op)| op != op::WRITE);
+        events
+    } else if cfg!(target_os="macos") {
+        inflate_events(recv_events(&rx))
+    } else {
+        recv_events(&rx)
+    };
+
+    if cfg!(target_os="windows") {
+        assert_eq!(actual, vec![
+            (path1, op::CREATE),
+            (sub_dir1a, op::RENAME),
+            (sub_dir1b, op::RENAME), // should be a create
+            (path2, op::CREATE)
+        ]);
+        panic!("move_to should be translated to create");
+    } else if cfg!(target_os="macos") {
+        assert_eq!(actual, vec![
+            (path1, op::CREATE),
+            (sub_dir1a, op::CREATE | op::RENAME), // excessive create event
+            (sub_dir1b, op::RENAME), // should be a create
+            (path2, op::CREATE)
+        ]);
+    } else {
+        assert_eq!(actual, vec![
+            (path1, op::CREATE),
+            (sub_dir1a, op::RENAME),
+            (sub_dir1b, op::CREATE),
+            (path2, op::CREATE)
+        ]);
+    }
+}
+
+#[test]
+#[ignore]
+fn watch_recursive_move_in() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut sub_dir1 = canonicalize(temp_dir.path());
+    sub_dir1.push("sub_dir1");
+    let mut sub_dir2 = sub_dir1.clone();
+    sub_dir2.push("sub_dir2");
+    let watch_dir = TempDir::new_in(temp_dir.path(), "watch_dir").expect("failed to create temporary directory");
+    let mut sub_dir1a = canonicalize(watch_dir.path());
+    sub_dir1a.push("sub_dir1");
+    let mut path = canonicalize(watch_dir.path());
+    path.push("sub_dir1");
+    path.push("sub_dir2");
+    path.push("new_file.bin");
+
+    fs::create_dir(sub_dir1.as_path()).expect("failed to create directory");
+    fs::create_dir(sub_dir2.as_path()).expect("failed to create directory");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
+    watcher.watch(watch_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    fs::rename(sub_dir1.as_path(), sub_dir1a.as_path()).expect("failed to rename file");
+    thread::sleep(Duration::from_millis(10));
+    fs::File::create(path.as_path()).expect("failed to create file");
+
+    let actual = if cfg!(target_os="windows") {
+        // Windows may sneak a write event in there
+        let mut events = recv_events(&rx);
+        events.retain(|&(_, op)| op != op::WRITE);
+        events
+    } else if cfg!(target_os="macos") {
+        inflate_events(recv_events(&rx))
+    } else {
+        recv_events(&rx)
+    };
+
+    if cfg!(target_os="macos") {
+        assert_eq!(actual, vec![
+            (sub_dir1a, op::RENAME), // fsevents interprets a move_to as a rename event
+            (path, op::CREATE)
+        ]);
+        panic!("move event should be a create event");
+    } else {
+        assert_eq!(actual, vec![
+            (sub_dir1a, op::CREATE),
+            (path, op::CREATE)
+        ]);
+    }
+}
+
+#[test]
+fn watch_recursive_move_out() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let watch_dir = TempDir::new_in(temp_dir.path(), "watch_dir").expect("failed to create temporary directory");
+
+    let mut sub_dir1a = canonicalize(watch_dir.path());
+    sub_dir1a.push("sub_dir1a");
+    let mut sub_dir1b = canonicalize(temp_dir.path());
+    sub_dir1b.push("sub_dir1b");
+    let mut sub_dir2 = sub_dir1a.clone();
+    sub_dir2.push("sub_dir2");
+    let mut path1 = canonicalize(watch_dir.path());
+    path1.push("sub_dir1a");
+    path1.push("sub_dir2");
+    path1.push("file1.bin");
+    let mut path2 = canonicalize(temp_dir.path());
+    path2.push("sub_dir1b");
+    path2.push("sub_dir2");
+    path2.push("file2.bin");
+
+    fs::create_dir(sub_dir1a.as_path()).expect("failed to create directory");
+    fs::create_dir(sub_dir2.as_path()).expect("failed to create directory");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
+    watcher.watch(watch_dir.into_path(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    fs::File::create(path1.as_path()).expect("failed to create file");
+    fs::rename(sub_dir1a.as_path(), sub_dir1b.as_path()).expect("failed to rename file");
+    thread::sleep(Duration::from_millis(10));
+    fs::File::create(path2.as_path()).expect("failed to create file");
+
+    let actual = if cfg!(target_os="windows") {
+        // Windows may sneak a write event in there
+        let mut events = recv_events(&rx);
+        events.retain(|&(_, op)| op != op::WRITE);
+        events
+    } else if cfg!(target_os="macos") {
+        inflate_events(recv_events(&rx))
+    } else {
+        recv_events(&rx)
+    };
+
+    if cfg!(target_os="windows") {
+        assert_eq!(actual, vec![
+            (path1, op::CREATE),
+            (sub_dir1a, op::REMOVE) // windows interprets a move out of the watched directory as a remove
+        ]);
+    } else if cfg!(target_os="macos") {
+        assert_eq!(actual, vec![
+            (path1, op::CREATE),
+            (sub_dir1a, op::CREATE | op::RENAME) // excessive create event
+        ]);
+    } else {
+        assert_eq!(actual, vec![
+            (path1, op::CREATE),
+            (sub_dir1a, op::RENAME)
+        ]);
+    }
+}
+
+#[test]
+fn watch_nonrecursive() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut sub_dir1 = canonicalize(temp_dir.path());
+    sub_dir1.push("sub_dir1");
+    let mut sub_dir2 = canonicalize(temp_dir.path());
+    sub_dir2.push("sub_dir2");
+    let mut file0 = canonicalize(temp_dir.path());
+    file0.push("file0.bin");
+    let mut file1 = sub_dir1.clone();
+    file1.push("file1.bin");
+    let mut file2 = sub_dir2.clone();
+    file2.push("file2.bin");
+
+    fs::create_dir(sub_dir1.as_path()).expect("failed to create directory");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
+    watcher.watch(temp_dir.into_path(), RecursiveMode::NonRecursive).expect("failed to watch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    fs::create_dir(sub_dir2.as_path()).expect("failed to create directory");
+    thread::sleep(Duration::from_millis(10));
+    fs::File::create(file0.as_path()).expect("failed to create file");
+    fs::File::create(file1.as_path()).expect("failed to create file");
+    fs::File::create(file2.as_path()).expect("failed to create file");
+
+    assert_eq!(recv_events(&rx), vec![
+        (sub_dir2, op::CREATE),
+        (file0, op::CREATE)
+    ]);
+}
+
+#[test]
+fn watch_file() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut path1 = canonicalize(temp_dir.path());
+    path1.push("file1.bin");
+    let mut path2 = canonicalize(temp_dir.path());
+    path2.push("file2.bin");
+
+    let mut file1 = fs::File::create(path1.as_path()).expect("failed to create file");
+
+    if cfg!(target_os="macos") {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).expect("failed to create recommended watcher");
+    watcher.watch(path1.clone(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    if cfg!(target_os="windows") {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    file1.write("some data".as_bytes()).expect("failed to write to file");
+    file1.sync_all().expect("failed to sync file");
+    if cfg!(target_os="macos") {
+        drop(file1); // file needs to be closed for fsevent
+    }
+
+    fs::File::create(path2.as_path()).expect("failed to create file");
+
+    if cfg!(target_os="macos") {
+        assert_eq!(recv_events(&rx), vec![
+            (path1, op::CREATE | op::WRITE)
+        ]);
+    } else {
+        assert_eq!(recv_events(&rx), vec![
+            (path1, op::WRITE)
+        ]);
+    }
 }

--- a/tests/watcher.rs
+++ b/tests/watcher.rs
@@ -1,0 +1,80 @@
+extern crate notify;
+extern crate tempdir;
+extern crate tempfile;
+extern crate time;
+
+mod utils;
+
+use notify::*;
+use std::sync::mpsc::{self, channel};
+use tempdir::TempDir;
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+use utils::*;
+
+#[cfg(target_os = "linux")]
+#[test]
+fn new_inotify() {
+    let (tx, _) = channel();
+    let w: Result<INotifyWatcher> = Watcher::new(tx);
+    assert!(w.is_ok());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn new_fsevent() {
+    let (tx, _) = channel();
+    let w: Result<FsEventWatcher> = Watcher::new(tx);
+    assert!(w.is_ok());
+}
+
+#[test]
+fn new_null() {
+    let (tx, _) = channel();
+    let w: Result<NullWatcher> = Watcher::new(tx);
+    assert!(w.is_ok());
+}
+
+#[test]
+fn new_poll() {
+    let (tx, _) = channel();
+    let w: Result<PollWatcher> = Watcher::new(tx);
+    assert!(w.is_ok());
+}
+
+#[test]
+fn new_recommended() {
+    let (tx, _) = channel();
+    let w: Result<RecommendedWatcher> = Watcher::new(tx);
+    assert!(w.is_ok());
+}
+
+// if this test builds, it means RecommendedWatcher is Send.
+#[test]
+fn test_watcher_send() {
+    let (tx, _) = channel();
+
+    let mut watcher: RecommendedWatcher = Watcher::new(tx).unwrap();
+
+    thread::spawn(move || {
+        watcher.watch(".", RecursiveMode::Recursive).unwrap();
+    }).join().unwrap();
+}
+
+// if this test builds, it means RecommendedWatcher is Sync.
+#[test]
+fn test_watcher_sync() {
+    use std::sync::{ Arc, RwLock };
+
+    let (tx, _) = channel();
+
+    let watcher: RecommendedWatcher = Watcher::new(tx).unwrap();
+    let watcher = Arc::new(RwLock::new(watcher));
+
+    thread::spawn(move || {
+        let mut watcher = watcher.write().unwrap();
+        watcher.watch(".", RecursiveMode::Recursive).unwrap();
+    }).join().unwrap();
+}

--- a/tests/watcher.rs
+++ b/tests/watcher.rs
@@ -118,7 +118,18 @@ fn watch_recursive_create_directory() {
 
     fs::File::create(file2.as_path()).expect("failed to create file");
 
-    assert_eq!(recv_events(&rx), vec![
+    let actual = if cfg!(target_os="windows") {
+        // Windows may sneak a write event in there
+        let mut events = recv_events(&rx);
+        events.retain(|&(_, op)| op != op::WRITE);
+        events
+    } else if cfg!(target_os="macos") {
+        inflate_events(recv_events(&rx))
+    } else {
+        recv_events(&rx)
+    };
+
+    assert_eq!(actual, vec![
         (new_dir, op::CREATE),
         (file1, op::CREATE)
     ]);
@@ -402,4 +413,276 @@ fn watch_file() {
             (path1, op::WRITE)
         ]);
     }
+}
+
+#[test]
+fn poll_watch_recursive_create_directory() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut new_dir = temp_dir.path().to_owned();
+    new_dir.push("new_dir");
+    let mut file1 = new_dir.clone();
+    file1.push("file1");
+    let mut file2 = new_dir.clone();
+    file2.push("file2");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = PollWatcher::with_delay(tx, 100).expect("failed to create recommended watcher");
+    watcher.watch(temp_dir.path().to_owned(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::create_dir(new_dir.as_path()).expect("failed to create directory");
+    fs::File::create(file1.as_path()).expect("failed to create file");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    watcher.unwatch(temp_dir.path().to_owned()).expect("failed to unwatch directory");
+
+    fs::File::create(file2.as_path()).expect("failed to create file");
+
+    let mut actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(actual, vec![
+        (temp_dir.into_path(), op::WRITE), // parent directory gets modified
+        (new_dir, op::CREATE),
+        (file1, op::CREATE)
+    ]);
+}
+
+#[test]
+fn poll_watch_recursive_move() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut sub_dir1a = temp_dir.path().to_owned();
+    sub_dir1a.push("sub_dir1a");
+    let mut sub_dir1b = temp_dir.path().to_owned();
+    sub_dir1b.push("sub_dir1b");
+    let mut path1a = temp_dir.path().to_owned();
+    path1a.push("sub_dir1a");
+    path1a.push("file1.bin");
+    let mut path1b = temp_dir.path().to_owned();
+    path1b.push("sub_dir1b");
+    path1b.push("file1.bin");
+    let mut path2 = temp_dir.path().to_owned();
+    path2.push("sub_dir1b");
+    path2.push("file2.bin");
+
+    fs::create_dir(sub_dir1a.as_path()).expect("failed to create directory");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = PollWatcher::with_delay(tx, 100).expect("failed to create recommended watcher");
+    watcher.watch(temp_dir.path().to_owned(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::File::create(path1a.as_path()).expect("failed to create file");
+
+    let mut actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(actual, vec![
+        (sub_dir1a.clone(), op::WRITE), // parent directory gets modified
+        (path1a.clone(), op::CREATE),
+    ]);
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::rename(sub_dir1a.as_path(), sub_dir1b.as_path()).expect("failed to rename file");
+    fs::File::create(path2.as_path()).expect("failed to create file");
+
+    actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if cfg!(target_os="windows") {
+        assert_eq!(actual, vec![
+            (temp_dir.into_path(), op::WRITE), // parent directory gets modified
+            (sub_dir1a, op::REMOVE),
+            (path1a, op::REMOVE),
+            (sub_dir1b.clone(), op::CREATE),
+            (sub_dir1b, op::WRITE), // parent directory gets modified
+            (path1b, op::CREATE),
+            (path2, op::CREATE),
+        ]);
+    } else {
+        assert_eq!(actual, vec![
+            (temp_dir.into_path(), op::WRITE), // parent directory gets modified
+            (sub_dir1a, op::REMOVE),
+            (path1a, op::REMOVE),
+            (sub_dir1b, op::CREATE),
+            (path1b, op::CREATE),
+            (path2, op::CREATE),
+        ]);
+    }
+}
+
+#[test]
+fn poll_watch_recursive_move_in() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut sub_dir1 = temp_dir.path().to_owned();
+    sub_dir1.push("sub_dir1");
+    let mut sub_dir2 = sub_dir1.clone();
+    sub_dir2.push("sub_dir2");
+    let watch_dir = TempDir::new_in(temp_dir.path(), "watch_dir").expect("failed to create temporary directory");
+    let mut sub_dir1a = watch_dir.path().to_owned();
+    sub_dir1a.push("sub_dir1");
+    let mut sub_dir2a = sub_dir1a.clone();
+    sub_dir2a.push("sub_dir2");
+    let mut path = watch_dir.path().to_owned();
+    path.push("sub_dir1");
+    path.push("sub_dir2");
+    path.push("new_file.bin");
+
+    fs::create_dir(sub_dir1.as_path()).expect("failed to create directory");
+    fs::create_dir(sub_dir2.as_path()).expect("failed to create directory");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = PollWatcher::with_delay(tx, 100).expect("failed to create recommended watcher");
+    watcher.watch(watch_dir.path().to_owned(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::rename(sub_dir1.as_path(), sub_dir1a.as_path()).expect("failed to rename file");
+    fs::File::create(path.as_path()).expect("failed to create file");
+
+    let mut actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if cfg!(target_os="windows") {
+        assert_eq!(actual, vec![
+            (watch_dir.into_path(), op::WRITE), // parent directory gets modified
+            (sub_dir1a, op::CREATE),
+            (sub_dir2a.clone(), op::CREATE),
+            (sub_dir2a, op::WRITE), // extra write event
+            (path, op::CREATE),
+        ]);
+    } else {
+        assert_eq!(actual, vec![
+            (watch_dir.into_path(), op::WRITE), // parent directory gets modified
+            (sub_dir1a, op::CREATE),
+            (sub_dir2a, op::CREATE),
+            (path, op::CREATE),
+        ]);
+    }
+}
+
+#[test]
+fn poll_watch_recursive_move_out() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let watch_dir = TempDir::new_in(temp_dir.path(), "watch_dir").expect("failed to create temporary directory");
+
+    let mut sub_dir1a = watch_dir.path().to_owned();
+    sub_dir1a.push("sub_dir1a");
+    let mut sub_dir1b = temp_dir.path().to_owned();
+    sub_dir1b.push("sub_dir1b");
+    let mut sub_dir2 = sub_dir1a.clone();
+    sub_dir2.push("sub_dir2");
+    let mut path1 = watch_dir.path().to_owned();
+    path1.push("sub_dir1a");
+    path1.push("sub_dir2");
+    path1.push("file1.bin");
+    let mut path2 = temp_dir.path().to_owned();
+    path2.push("sub_dir1b");
+    path2.push("sub_dir2");
+    path2.push("file2.bin");
+
+    fs::create_dir(sub_dir1a.as_path()).expect("failed to create directory");
+    fs::create_dir(sub_dir2.as_path()).expect("failed to create directory");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = PollWatcher::with_delay(tx, 100).expect("failed to create recommended watcher");
+    watcher.watch(watch_dir.path().to_owned(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::File::create(path1.as_path()).expect("failed to create file");
+
+    let mut actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(actual, vec![
+        (sub_dir2.clone(), op::WRITE), // parent directory gets modified
+        (path1.clone(), op::CREATE),
+    ]);
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::rename(sub_dir1a.as_path(), sub_dir1b.as_path()).expect("failed to rename file");
+    fs::File::create(path2.as_path()).expect("failed to create file");
+
+    actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(actual, vec![
+        (watch_dir.into_path(), op::WRITE), // parent directory gets modified
+        (sub_dir1a, op::REMOVE),
+        (sub_dir2, op::REMOVE),
+        (path1, op::REMOVE),
+    ]);
+}
+
+#[test]
+fn poll_watch_nonrecursive() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut sub_dir1 = temp_dir.path().to_owned();
+    sub_dir1.push("sub_dir1");
+    let mut sub_dir2 = temp_dir.path().to_owned();
+    sub_dir2.push("sub_dir2");
+    let mut file0 = temp_dir.path().to_owned();
+    file0.push("file0.bin");
+    let mut file1 = sub_dir1.clone();
+    file1.push("file1.bin");
+    let mut file2 = sub_dir2.clone();
+    file2.push("file2.bin");
+
+    fs::create_dir(sub_dir1.as_path()).expect("failed to create directory");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = PollWatcher::with_delay(tx, 100).expect("failed to create recommended watcher");
+    watcher.watch(temp_dir.path().to_owned(), RecursiveMode::NonRecursive).expect("failed to watch directory");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    fs::create_dir(sub_dir2.as_path()).expect("failed to create directory");
+    fs::File::create(file0.as_path()).expect("failed to create file");
+    fs::File::create(file1.as_path()).expect("failed to create file");
+    fs::File::create(file2.as_path()).expect("failed to create file");
+
+    let mut actual = recv_events(&rx);
+    actual.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(actual, vec![
+        (temp_dir.into_path(), op::WRITE), // parent directory gets modified
+        (file0, op::CREATE),
+        (sub_dir1, op::WRITE), // parent directory gets modified
+        (sub_dir2, op::CREATE),
+    ]);
+}
+
+#[test]
+fn poll_watch_file() {
+    let temp_dir = TempDir::new("temp_dir").expect("failed to create temporary directory");
+    let mut path1 = temp_dir.path().to_owned();
+    path1.push("file1.bin");
+    let mut path2 = temp_dir.path().to_owned();
+    path2.push("file2.bin");
+
+    let mut file1 = fs::File::create(path1.as_path()).expect("failed to create file");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = PollWatcher::with_delay(tx, 100).expect("failed to create recommended watcher");
+    watcher.watch(path1.clone(), RecursiveMode::Recursive).expect("failed to watch directory");
+
+    thread::sleep(Duration::from_millis(1100)); // PollWatcher has only a resolution of 1 second
+
+    file1.write("some data".as_bytes()).expect("failed to write to file");
+    file1.sync_all().expect("failed to sync file");
+    if cfg!(target_os="macos") {
+        drop(file1); // file needs to be closed for fsevent
+    }
+
+    fs::File::create(path2.as_path()).expect("failed to create file");
+
+    assert_eq!(recv_events(&rx), vec![
+        (path1, op::WRITE)
+    ]);
 }

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -37,7 +37,7 @@ fn shutdown() {
 
         for d in &dirs { // need the ref, otherwise its a move and the dir will be dropped!
             //println!("{:?}", d.path());
-            w.watch(d.path()).unwrap();
+            w.watch(d.path(), RecursiveMode::Recursive).unwrap();
         }
 
         // unwatch half of the directories, let the others get stopped when we go out of scope
@@ -76,7 +76,7 @@ fn watch_deleted_fails() {
 
     let (tx, _) = channel();
     let mut w = ReadDirectoryChangesWatcher::new(tx).unwrap();
-    match w.watch(pb.as_path()) {
+    match w.watch(pb.as_path(), RecursiveMode::Recursive) {
         Ok(x) => panic!("Should have failed, but got: {:?}", x),
         Err(_) => ()
     }
@@ -91,11 +91,11 @@ fn watch_server_can_be_awakened() {
     let d = TempDir::new("rsnotifytest").unwrap();
     let d2 = TempDir::new("rsnotifytest").unwrap();
 
-    match w.watch(d.path()) {
+    match w.watch(d.path(), RecursiveMode::Recursive) {
         Ok(_) => (),
         Err(e) => panic!("Oops: {:?}", e)
     }
-    match w.watch(d2.path()) {
+    match w.watch(d2.path(), RecursiveMode::Recursive) {
         Ok(_) => (),
         Err(e) => panic!("Oops: {:?}", e)
     }
@@ -130,7 +130,7 @@ fn memtest_manual() {
         {
             let (meta_tx,_) = channel();
             let mut w = ReadDirectoryChangesWatcher::create(tx,meta_tx).unwrap();
-            w.watch(d.path()).unwrap();
+            w.watch(d.path(), RecursiveMode::Recursive).unwrap();
             thread::sleep_ms(1); // this should make us run pretty hot but not insane
         }
         check_for_error(&rx);


### PR DESCRIPTION
This patch normalizes the recursive behavior of the various back-ends when adding watches.
Currently inotify initially watches directories recursively, but doesn't watch new directories and cannot unwatch directories recursively.
Windows and FSEvent watch directories recursively and automatically watch new directories.

With this patch, all back-ends can watch directories recursively (while automatically watching new directories) or non-recursively depending on a new flag for the watch(..) function.
It also fixes a memory leak in the inotify back-end.

I implemented CREATE and DELETE for PollWatcher in order to make it compatible with the new tests.
And I increased the PollWatcher's default delay to 10 seconds. I guess that the default value of 10 ms was a mistake, since that seems a bit low. Plus the PollWatcher has only a time resolution of 1 second anyway.

I also moved some code from tests/notify.rs. to the new files tests/watcher.rs and tests/utils.rs in order to reduce its size.

Here are some issues, this patch might affect:
Fixes: #60
Fixes: #61
Implements some features from: #20
Fixes: #68