### PR TITLE
Add IN_CLOSE_WRITE event in inotify

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -161,6 +161,9 @@ impl mio::Handler for INotifyHandler {
                                     if event.is_modify() {
                                         o.insert(op::WRITE);
                                     }
+                                    if event.is_close_write() {
+                                        o.insert(op::CLOSEWRITE);
+                                    }
                                     if event.is_attrib() {
                                         o.insert(op::CHMOD);
                                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,8 +291,10 @@ pub mod op {
             const RENAME  = 0b001000,
             /// Written
             const WRITE   = 0b010000,
+            /// Written
+            const CLOSEWRITE   = 0b100000,
             /// Directories need to be rescanned
-            const RESCAN  = 0b100000,
+            const RESCAN  = 0b1000000,
         }
     }
 }


### PR DESCRIPTION
The IN_MODIFY event is emitted on a file content change (e.g. via the write() syscall) while IN_CLOSE_WRITE occurs on closing the changed file. It means each change operation causes one IN_MODIFY event (it may occur many times during manipulations with an open file) whereas IN_CLOSE_WRITE is emitted only once (on closing the file).