### PR TITLE
Add IN_CLOSE_WRITE Event

### DIFF
--- a/src/inotify/mod.rs
+++ b/src/inotify/mod.rs
@@ -161,6 +161,9 @@ impl mio::Handler for INotifyHandler {
                                     if event.is_modify() {
                                         o.insert(op::WRITE);
                                     }
+                                    if event.is_close_write() {
+                                        o.insert(op::CLOSE_WRITE);
+                                    }
                                     if event.is_attrib() {
                                         o.insert(op::CHMOD);
                                     }
@@ -253,7 +256,7 @@ impl INotifyHandler {
     }
 
     fn add_single_watch(&mut self, path: PathBuf, is_recursive: bool, watch_self: bool) -> Result<()> {
-        let mut flags = flags::IN_ATTRIB | flags::IN_CREATE | flags::IN_DELETE |
+        let mut flags = flags::IN_ATTRIB | flags::IN_CREATE | flags::IN_DELETE | flags::IN_CLOSE_WRITE | 
                         flags::IN_MODIFY | flags::IN_MOVED_FROM | flags::IN_MOVED_TO;
 
         if watch_self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,8 +291,10 @@ pub mod op {
             const RENAME  = 0b001000,
             /// Written
             const WRITE   = 0b010000,
+            /// Written
+            const CLOSE_WRITE   = 0b100000,
             /// Directories need to be rescanned
-            const RESCAN  = 0b100000,
+            const RESCAN  = 0b1000000,
         }
     }
 }

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -48,9 +48,14 @@ fn create_file() {
         assert_eq!(inflate_events(recv_events(&rx)), vec![
             (tdir.mkpath("file1"), op::CREATE, None),
         ]);
+    } else if cfg!(target_os="windows") {
+        assert_eq!(recv_events(&rx), vec![
+            (tdir.mkpath("file1"), op::CREATE, None)
+        ]);
     } else {
         assert_eq!(recv_events(&rx), vec![
             (tdir.mkpath("file1"), op::CREATE, None),
+            (tdir.mkpath("file1"), op::CLOSE_WRITE, None)
         ]);
     }
 }
@@ -77,9 +82,14 @@ fn write_file() {
         assert_eq!(inflate_events(recv_events(&rx)), vec![
             (tdir.mkpath("file1"), op::CREATE | op::WRITE, None), // excessive create event
         ]);
+    } else if cfg!(target_os="windows") {
+        assert_eq!(recv_events(&rx), vec![
+            (tdir.mkpath("file1"), op::WRITE, None)
+        ]);
     } else {
         assert_eq!(recv_events(&rx), vec![
             (tdir.mkpath("file1"), op::WRITE, None),
+            (tdir.mkpath("file1"), op::CLOSE_WRITE, None)
         ]);
     }
 }
@@ -297,8 +307,9 @@ fn create_rename_overwrite_file() {
         assert_eq!(cookies.len(), 1);
         assert_eq!(actual, vec![
             (tdir.mkpath("file1a"), op::CREATE, None),
+            (tdir.mkpath("file1a"), op::CLOSE_WRITE, None),
             (tdir.mkpath("file1a"), op::RENAME, Some(cookies[0])),
-            (tdir.mkpath("file1b"), op::RENAME, Some(cookies[0])),
+            (tdir.mkpath("file1b"), op::RENAME, Some(cookies[0]))
         ]);
     }
 }


### PR DESCRIPTION
The IN_MODIFY event is emitted on a file content change (e.g. via the write() syscall) while IN_CLOSE_WRITE occurs on closing the changed file. It means each change operation causes one IN_MODIFY event (it may occur many times during manipulations with an open file) whereas IN_CLOSE_WRITE is emitted only once (on closing the file).